### PR TITLE
Revocation Tests

### DIFF
--- a/gabi_test.go
+++ b/gabi_test.go
@@ -650,6 +650,7 @@ func TestNotRevoked(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, new(big.Int).Exp(witness.U, witness.E, testPubK.N).Cmp(acc.Nu))
 
+	// Issuance
 	signature, err := SignMessageBlock(testPrivK, testPubK, testAttributes1, witness.E)
 	require.NoError(t, err)
 	require.True(t, signature.Verify(testPubK, testAttributes1, witness.E))
@@ -662,6 +663,7 @@ func TestNotRevoked(t *testing.T) {
 	}
 	require.NoError(t, cred.NonrevPrepareCache())
 
+	// showing
 	context, _ := common.RandomBigInt(testPubK.Params.Lh)
 	nonce, _ := common.RandomBigInt(testPubK.Params.Lstatzk)
 
@@ -695,7 +697,8 @@ func TestRevoked(t *testing.T) {
 	witness.Accumulator = acc
 	require.NoError(t, err)
 	require.Zero(t, new(big.Int).Exp(witness.U, witness.E, testPubK.N).Cmp(witness.Accumulator.Nu))
-
+	
+	// Issuance
 	signature, err := SignMessageBlock(testPrivK, testPubK, testAttributes1, witness.E)
 	require.NoError(t, err)
 	require.True(t, signature.Verify(testPubK, testAttributes1, witness.E))
@@ -755,15 +758,10 @@ func TestFullIssueAndShowWithRevocation(t *testing.T) {
 	require.NoError(t, err, "Error in ConstructCredential")
 
 	// Showing
-	n1, _ := common.RandomBigInt(testPubK.Params.Lstatzk)
-	disclosed := []int{1, 2}
-
-	pb, err := cred.CreateDisclosureProofBuilder(disclosed, true)
-	require.NoError(t, err)
-	challenge := ProofBuilderList{pb}.Challenge(context, n1, true)
-	proofd := pb.CreateProof(challenge).(*ProofD)
-
-	assert.True(t, ProofList{proofd}.Verify([]*PublicKey{testPubK}, context, n1, false, nil))
+	nonce1s, _ := common.RandomBigInt(testPubK.Params.Lstatzk)
+	disclosedAttributes := []int{1, 3}
+	proof := cred.CreateDisclosureProof(disclosedAttributes, context, nonce1s)
+	assert.True(t, proof.Verify(testPubK, context, nonce1s, false), "Proof of disclosure did not verify, whereas it should.")
 }
 
 // TODO: tests to add:

--- a/gabi_test.go
+++ b/gabi_test.go
@@ -5,8 +5,6 @@
 package gabi
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -646,6 +644,9 @@ func TestRevocation(t *testing.T) {
 	acc, err := update.SignedAccumulator.UnmarshalVerify(revpk)
 
 	witness, err := testPrivK.RevocationGenerateWitness(acc)
+	witness.Accumulator = acc
+	witness.SignedAccumulator = update.SignedAccumulator
+
 	require.NoError(t, err)
 	require.Zero(t, new(big.Int).Exp(witness.U, witness.E, testPubK.N).Cmp(witness.Accumulator.Nu))
 
@@ -669,9 +670,9 @@ func TestRevocation(t *testing.T) {
 	challenge := ProofBuilderList{b}.Challenge(context, nonce, false)
 	proofd := b.CreateProof(challenge)
 
-	bts, err := json.MarshalIndent(proofd, "", "    ")
-	require.NoError(t, err)
-	fmt.Println(string(bts))
+	// bts, err := json.MarshalIndent(proofd, "", "    ")
+	// require.NoError(t, err)
+	// fmt.Println(string(bts))
 
 	require.True(t, ProofList{proofd}.Verify([]*PublicKey{testPubK}, context, nonce, false, nil))
 }

--- a/keys.go
+++ b/keys.go
@@ -170,7 +170,7 @@ func (privk *PrivateKey) RevocationSupported() bool {
 
 func GenerateRevocationKeypair(privk *PrivateKey, pubk *PublicKey) error {
 	if pubk.RevocationSupported() || privk.RevocationSupported() {
-		return errors.New("revocation parameters already present")
+		return nil
 	}
 
 	key, err := signed.GenerateKey()

--- a/revocation/api.go
+++ b/revocation/api.go
@@ -355,7 +355,7 @@ func (event *Event) hash() Hash {
 }
 
 func (event *Event) hashBytes() []byte {
-	bts := make([]byte, 8, 8+len(event.ParentHash)+int(parameters.attributeMaxSize)/8+1)
+	bts := make([]byte, 8, 8+len(event.ParentHash)+int(parameters.attributeSize)/8+1)
 	binary.BigEndian.PutUint64(bts, event.Index)
 	bts = append(bts, event.ParentHash[:]...)
 	bts = append(bts, event.E.Bytes()...)

--- a/revocation/api.go
+++ b/revocation/api.go
@@ -89,8 +89,8 @@ type (
 
 	// SignedAccumulator is an Accumulator signed with the issuer's ECDSA key, along with the key index.
 	SignedAccumulator struct {
-		Data    signed.Message `json:"data"`
-		PKIndex uint           `json:"pkindex"`
+		Data      signed.Message `json:"data"`
+		PKCounter uint           `json:"pk"`
 	}
 
 	// Event contains the data clients need to update to the Accumulator of the specified index,
@@ -184,7 +184,7 @@ func (acc *Accumulator) Sign(sk *PrivateKey) (*SignedAccumulator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SignedAccumulator{Data: sig, PKIndex: sk.Counter}, nil
+	return &SignedAccumulator{Data: sig, PKCounter: sk.Counter}, nil
 }
 
 // Remove generates a new accumulator with the specified e removed from it; signs it;
@@ -221,7 +221,7 @@ func (acc *Accumulator) Remove(sk *PrivateKey, e *big.Int, parent *Event) (*Upda
 // (c.f. Accumulator.Sign()).
 func (s *SignedAccumulator) UnmarshalVerify(pk *PublicKey) (*Accumulator, error) {
 	msg := &Accumulator{}
-	if pk.Counter != s.PKIndex {
+	if pk.Counter != s.PKCounter {
 		return nil, errors.New("wrong public key")
 	}
 	if err := signed.UnmarshalVerify(pk.ECDSA, s.Data, msg); err != nil {

--- a/revocation/api.go
+++ b/revocation/api.go
@@ -323,7 +323,7 @@ func (update *Update) Verify(pk *PublicKey, index uint64) (*Accumulator, *big.In
 			}
 		}
 		if uint64(i)+startIndex != event.Index {
-			return nil, nil, errors.Errorf("event %d has wrong index, found %d, expected %d", event.Index, uint64(i)+startIndex)
+			return nil, nil, errors.Errorf("event %d has wrong index, found %d, expected %d", event, event.Index, uint64(i)+startIndex)
 		}
 		if uint64(i)+startIndex <= index {
 			continue

--- a/revocation/api.go
+++ b/revocation/api.go
@@ -323,7 +323,7 @@ func (update *Update) Verify(pk *PublicKey, index uint64) (*Accumulator, *big.In
 			}
 		}
 		if uint64(i)+startIndex != event.Index {
-			return nil, nil, errors.Errorf("event %d has wrong index, found %d, expected %d", event, event.Index, uint64(i)+startIndex)
+			return nil, nil, errors.Errorf("event %+v has wrong index, found %d, expected %d", event, event.Index, uint64(i)+startIndex)
 		}
 		if uint64(i)+startIndex <= index {
 			continue

--- a/revocation/proof.go
+++ b/revocation/proof.go
@@ -31,19 +31,45 @@ with the following differences.
    in our case everything happens within QR_n.
 2. The fifth relation C_e = g^e * h^r1 is replaced by the Idemix relation
    Z = A^epsilon * S^v * Ri^mi * Re^e which is already proved elsewhere by the calling code.
-3. The bounds A and B between which the witness e is chosen does not satisfy the relation
-   B*2^(k'+k''+1) < A^2 - 1, which again would only be relevant in the presence of a known prime
-   order group. Instead we take for B the maximum size such that e still fits in an IRMA attribute
-   in 1024 parameter settings and A one bit below. This ensures that with overwhelming probability
-   no e will be chosen twice.
+3. The interval [A, B] from which the witness e is chosen does not satisfy the relation
+   B*2^(k'+k''+1) < A^2 - 1, which is unnecessary: as long as A > 2 witnesses are unforgeable,
+   by a simple extension of the unforgeability proof of Theorem 3. See below.
+In the following we follow the lead of the other zero knowledge proofs implemented elsehwere in gabi.
 4. Secrets and randomizers within the zero-knowledge proofs are taken positive, instead of from
    symmetric intervals [-A,A].
-5. like the rest of IRMA but unlike the paper, we use addition in the zero-knowledge proof responses:
-   response = randomizer + challenge*secret.
+5. We use addition in the zero-knowledge proof responses: response = randomizer + challenge*secret.
 6. We use the Fiat-Shamir heuristic.
-7. Like in the rest of IRMA but unlike page 15 we include the challenge c in the proof, and then
-   verify by hashing the Schnorr commitments reconstructed from the proof, obtaining c' which must
-   equal c.
+7. We include the challenge c in the proof, and then verify by hashing the Schnorr commitments
+   reconstructed from the proof, obtaining c' which must then equal c.
+
+We claim, prove, and implement the following:
+Let [A, B] be the interval from which the number e from the witness (u,e) is chosen, as in the paper.
+Then witnesses are unforgeable as in theorem 3, if A > 2 and B < 2^(l_n-1) where l_n
+is the bitsize of the modulus n. In particular, it is not necesary to assume A^2 > B
+like theorem 3 does.
+
+Proof: let (u')^(x') = u^x where x = x_1*...*x_n, and set d = gcd(x, x'), as in the proof.
+Suppose that d is not relatively prime to phi(n) = 4*p'*q', i.e. d divides 4*p'*q'.
+Now d <= x' < 2^(l_n-1) < phi(n), and d > 2 because x_j > 2 for all j.
+So d can only equal p' or q' or p'*q'. In the first two cases, we have succeeded in factoring
+n = p*q = (2p'+1)(2q'+1). In the third case, given p'*q' it is easy to check if
+4*p'*q' = (p-1)(q-1) is the group modulus. If so then p and q, thus also p' and q',
+can be reconstructed. Thus n is also factored.
+The remainder of the proof which handles the other case, where d is relatively prime
+to phi(n), works as is.
+The claim "d = gcd(x,x') => (d = 1 or d = x_j)" in the middle of the proof, which requires
+A^2 > B for its proof, is thus not necessary to use in the proof of theorem 3.
+
+Thus for unforgeability the size of e is not relevant. However, e should be chosen from a set so large
+that it is overhelmingly unlikely that any one prime e is chosen twice. Combining the prime counting
+function with the birthday paradox and simplifying, one finds the following: if N witnesses are chosen
+from the set of primes smaller than B, then the collision chance P approximately equals
+   P = 1 - e^(-N^2 ln(B)/B).
+At n = 10^9 we have P = 1/2^128 if B = 2^195.
+The client also proves to the verifier that e < B * 2^(k'+k''+2) = 2^(k'+k''+197),
+where k' = 128 is the security parameter of the statistical zero-knoweldgeness of the proof
+and k'' = 256 is the length of the challenge used in the zero knowledge proof. This is far
+below the limit 2^(l_n-1).
 */
 
 type (
@@ -88,16 +114,14 @@ var (
 	ErrorRevoked = errors.New("revoked")
 
 	parameters = struct {
-		attributeMinSize    uint     // minimum size in bits for prime e
-		attributeMaxSize    uint     // maximum size in bits for prime e
-		challengeLength     uint     // k'  = len(SHA256) = 256
-		zkStat              uint     // k'' = 128
-		twoZk, bTwoZk, a, b *big.Int // 2^(k'+k''), B*2^(k'+k''+1), 2^attributeMinSize, 2^attributeMaxSize
+		attributeSize    uint     // maximum size in bits for prime e
+		challengeLength  uint     // k'  = len(SHA256) = 256
+		zkStat           uint     // k'' = 128
+		twoZk, bTwoZk, b *big.Int // 2^(k'+k''), B*2^(k'+k''+1), 2^attributeSize
 	}{
-		attributeMinSize: 207,
-		attributeMaxSize: 208,
-		challengeLength:  256,
-		zkStat:           128,
+		attributeSize:   195,
+		challengeLength: 256,
+		zkStat:          128,
 	}
 
 	bigOne         = big.NewInt(1)
@@ -130,9 +154,8 @@ var (
 
 func init() {
 	// Compute derivative parameters
+	parameters.b = new(big.Int).Lsh(bigOne, parameters.attributeSize)
 	parameters.twoZk = new(big.Int).Lsh(bigOne, parameters.challengeLength+parameters.zkStat)
-	parameters.a = new(big.Int).Lsh(bigOne, parameters.attributeMinSize)
-	parameters.b = new(big.Int).Lsh(bigOne, parameters.attributeMaxSize)
 	parameters.bTwoZk = new(big.Int).Mul(parameters.b, new(big.Int).Mul(parameters.twoZk, big.NewInt(2)))
 }
 
@@ -146,7 +169,7 @@ func NewProofRandomizer() *big.Int {
 
 // RandomWitness returns a new random Witness valid against the specified Accumulator.
 func RandomWitness(sk *PrivateKey, acc *Accumulator) (*Witness, error) {
-	e, err := common.RandomPrimeInRange(rand.Reader, parameters.attributeMinSize, parameters.attributeMinSize)
+	e, err := common.RandomPrimeInRange(rand.Reader, 3, parameters.attributeSize)
 	if err != nil {
 		return nil, err
 	}

--- a/revocation/proof_test.go
+++ b/revocation/proof_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/privacybydesign/gabi/keyproof"
+	"github.com/privacybydesign/gabi/signed"
 	"github.com/stretchr/testify/require"
 
 	"github.com/privacybydesign/gabi/big"
@@ -59,8 +60,13 @@ func TestNonRevocationProof(t *testing.T) {
 }
 
 func test(t *testing.T, grp qrGroup, p, q *big.Int, valid bool) bool {
+	privECDSAKey, err := signed.GenerateKey()
+	privKey := PrivateKey{P: p, Q: q, N: grp.N, ECDSA: privECDSAKey}
+	require.NoError(t, err)
+
 	acc := &accumulator{Nu: common.RandomQR(grp.N)}
-	witn, err := RandomWitness(&PrivateKey{P: p, Q: q, N: grp.N}, (*Accumulator)(acc))
+
+	witn, err := RandomWitness(&privKey, (*Accumulator)(acc))
 	require.NoError(t, err)
 	require.NoError(t, err, "failed to generate non-revocation witness")
 	if !valid {
@@ -68,23 +74,24 @@ func test(t *testing.T, grp qrGroup, p, q *big.Int, valid bool) bool {
 	}
 
 	witn.randomizer = NewProofRandomizer()
-
-	bases := keyproof.NewBaseMerge(grp, acc)
+	witn.Accumulator = (*Accumulator)(acc)
+	bases := keyproof.NewBaseMerge(&grp, acc)
 	require.Equal(t, valid, proofstructure.isTrue((*witness)(witn), acc.Nu, grp.N), "statement to prove ")
 
 	start := time.Now()
 
-	list, commit := proofstructure.generateCommitmentsFromSecrets(grp, []*big.Int{}, &bases, (*witness)(witn))
+	list, commit := proofstructure.generateCommitmentsFromSecrets(&grp, []*big.Int{}, &bases, (*witness)(witn))
 	challenge := common.HashCommit(list, false)
+	sacc, err := ((*Accumulator)(acc)).Sign(&privKey)
+	require.NoError(t, err)
 	prf := (*ProofCommit)(&commit).BuildProof(challenge)
-
+	prf.SignedAccumulator = sacc
 	fmt.Println(time.Now().Sub(start))
 
-	//bts, err := json.MarshalIndent(prf, "", "    ")
-	//require.NoError(t, err, "failed to serialize prf")
-	//fmt.Println(string(bts))
+	// bts, err := json.MarshalIndent(prf, "", "    ")
+	// require.NoError(t, err, "failed to serialize prf")
+	// fmt.Println(string(bts))
 
-	start = time.Now()
 	defer fmt.Println(time.Now().Sub(start))
-	return (*proof)(&prf).verify(grp)
+	return (*proof)(prf).verify(&PublicKey{Group: (*QrGroup)(&grp), Counter: privKey.Counter, ECDSA: &privECDSAKey.PublicKey})
 }

--- a/revocation/qrgroup.go
+++ b/revocation/qrgroup.go
@@ -40,10 +40,10 @@ func (g *qrGroup) GetBase(name string) *big.Int {
 	}
 }
 
-func (g *qrGroup) Exp(ret *big.Int, name string, exp, n *big.Int) bool {
+func (g *qrGroup) Exp(ret *big.Int, name string, exp, P *big.Int) bool {
 	switch name {
 	case "g", "h":
-		ret.Exp(g.GetBase(name), exp, n)
+		ret.Exp(g.GetBase(name), exp, P)
 		return true
 	}
 	return false


### PR DESCRIPTION
I tried to fix some test which where failing. I also noticed that the `NonRevocationWitness` is not set inside `IssueSignature`. I think that it would make sense to set it there.

I also noticed that currently it is not possible to create proofs for credentials containing a revocation witness using the `CreateDisclosureProof` function (test `TestFullIssueAndShowWithRevocation`). I couldn't figure out how to fix this.

`GenerateRevocationKeypair` could be used to ensure that a key supports revocation. For that the method should not return an error if revocation is supported.