### PR TITLE
Several small rangeproof fixes

### DIFF
--- a/gabi_test.go
+++ b/gabi_test.go
@@ -624,34 +624,35 @@ func createCredential(t *testing.T, context, secret *big.Int, issuer *Issuer) *C
 var squaresTable = rangeproof.GenerateSquaresTable(65535)
 
 func TestRangeProofGreaterOrEqual(t *testing.T) {
-	testRangeProofs(t, true, []*rangeproof.Statement{
-		rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Sub(testAttributes1[0], big.NewInt(63))),
-	})
+	stmt, err := rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Sub(testAttributes1[0], big.NewInt(63)))
+	assert.NoError(t, err)
+	testRangeProofs(t, true, []*rangeproof.Statement{stmt})
 }
 
 func TestRangeProofEqual(t *testing.T) {
-	testRangeProofs(t, true, []*rangeproof.Statement{
-		rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Set(testAttributes1[0])),
-	})
+	stmt, err := rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Set(testAttributes1[0]))
+	assert.NoError(t, err)
+	testRangeProofs(t, true, []*rangeproof.Statement{stmt})
 }
 
 func TestRangeProofLesserOrEqual(t *testing.T) {
-	testRangeProofs(t, true, []*rangeproof.Statement{
-		rangeproof.NewStatement(rangeproof.LesserOrEqual, new(big.Int).Add(testAttributes1[0], big.NewInt(63))),
-	})
+	stmt, err := rangeproof.NewStatement(rangeproof.LesserOrEqual, new(big.Int).Add(testAttributes1[0], big.NewInt(63)))
+	assert.NoError(t, err)
+	testRangeProofs(t, true, []*rangeproof.Statement{stmt})
 }
 
 func TestRangeProofMultiple(t *testing.T) {
-	testRangeProofs(t, true, []*rangeproof.Statement{
-		rangeproof.NewStatement(rangeproof.LesserOrEqual, new(big.Int).Add(testAttributes1[0], big.NewInt(63))),
-		rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Sub(testAttributes1[0], big.NewInt(63))),
-	})
+	stmt1, err := rangeproof.NewStatement(rangeproof.LesserOrEqual, new(big.Int).Add(testAttributes1[0], big.NewInt(63)))
+	assert.NoError(t, err)
+	stmt2, err := rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Sub(testAttributes1[0], big.NewInt(63)))
+	assert.NoError(t, err)
+	testRangeProofs(t, true, []*rangeproof.Statement{stmt1, stmt2})
 }
 
 func TestRangeProofFalseStatement(t *testing.T) {
-	testRangeProofs(t, false, []*rangeproof.Statement{
-		rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Add(testAttributes1[0], big.NewInt(63))),
-	})
+	stmt, err := rangeproof.NewStatement(rangeproof.GreaterOrEqual, new(big.Int).Add(testAttributes1[0], big.NewInt(63)))
+	assert.NoError(t, err)
+	testRangeProofs(t, false, []*rangeproof.Statement{stmt})
 }
 
 func testRangeProofs(t *testing.T, trueStatements bool, statements []*rangeproof.Statement) {
@@ -688,7 +689,9 @@ func testRangeProofs(t *testing.T, trueStatements bool, statements []*rangeproof
 			typ, factor, bound := proof.RangeProofs[1][i].ProvenStatement()
 			assert.Equal(t, statement.Bound, bound)
 			assert.Equal(t, uint(1), factor)
-			assert.Equal(t, statement.Sign, typ.Sign())
+			sign, err := typ.Sign()
+			assert.NoError(t, err)
+			assert.Equal(t, statement.Sign, sign)
 
 			// The proof proves the statement as is
 			assert.True(t, proof.RangeProofs[1][i].Proves(statement))

--- a/gabi_test.go
+++ b/gabi_test.go
@@ -670,6 +670,7 @@ func testRangeProofs(t *testing.T, trueStatements bool, statements []*rangeproof
 			statement.Splitter = splitter
 		}
 
+		// prover part: create a disclosure proof
 		proof, err := cred.CreateDisclosureProof(
 			[]int{2}, map[int][]*rangeproof.Statement{1: statements}, false, context, nonce,
 		)
@@ -679,6 +680,7 @@ func testRangeProofs(t *testing.T, trueStatements bool, statements []*rangeproof
 			continue
 		}
 
+		// verifier part: verify disclosure proof and check the proven statement
 		require.NoError(t, err)
 		assert.True(t, proof.Verify(testPubK1, context, nonce, false))
 

--- a/gabi_test.go
+++ b/gabi_test.go
@@ -685,11 +685,22 @@ func testRangeProofs(t *testing.T, trueStatements bool, statements []*rangeproof
 		assert.True(t, proof.Verify(testPubK1, context, nonce, false))
 
 		for i, statement := range statements {
-			assert.True(t, proof.RangeProofs[1][i].Proves(statement))
 			typ, factor, bound := proof.RangeProofs[1][i].ProvenStatement()
 			assert.Equal(t, statement.Bound, bound)
 			assert.Equal(t, uint(1), factor)
 			assert.Equal(t, statement.Sign, typ.Sign())
+
+			// The proof proves the statement as is
+			assert.True(t, proof.RangeProofs[1][i].Proves(statement))
+
+			if statement.Sign == 1 {
+				// If attr >= bound, then also attr >= bound - 1
+				statement.Bound.Sub(statement.Bound, big.NewInt(1))
+			} else {
+				// If attr <= bound, then also attr <= bound + 1
+				statement.Bound.Add(statement.Bound, big.NewInt(1))
+			}
+			assert.True(t, proof.RangeProofs[1][i].Proves(statement))
 		}
 	}
 }

--- a/gabi_test.go
+++ b/gabi_test.go
@@ -684,6 +684,10 @@ func testRangeProofs(t *testing.T, trueStatements bool, statements []*rangeproof
 
 		for i, statement := range statements {
 			assert.True(t, proof.RangeProofs[1][i].Proves(statement))
+			typ, factor, bound := proof.RangeProofs[1][i].ProvenStatement()
+			assert.Equal(t, statement.Bound, bound)
+			assert.Equal(t, uint(1), factor)
+			assert.Equal(t, statement.Sign, typ.Sign())
 		}
 	}
 }

--- a/proofs.go
+++ b/proofs.go
@@ -273,7 +273,9 @@ func (p *ProofD) ChallengeContribution(pk *gabikeys.PublicKey) ([]*big.Int, erro
 
 	if p.RangeProofs != nil {
 		if p.cachedRangeStructures == nil {
-			p.reconstructRangeProofStructures(pk)
+			if err := p.reconstructRangeProofStructures(pk); err != nil {
+				return nil, err
+			}
 		}
 		// need stable attribute order for rangeproof contributions, so determine max undisclosed attribute
 		maxAttribute := 0

--- a/rangeproof/proof.go
+++ b/rangeproof/proof.go
@@ -455,8 +455,11 @@ func (p *Proof) ProvenStatement() (StatementType, uint, *big.Int) {
 		bound.Add(bound, big.NewInt(2)).Rsh(bound, 2)
 		factor >>= 2
 	}
-	typ := GreaterOrEqual
-	if p.Sign == -1 {
+	var typ StatementType
+	switch p.Sign {
+	case 1:
+		typ = GreaterOrEqual
+	case -1:
 		typ = LesserOrEqual
 	}
 	return typ, factor, bound

--- a/rangeproof/proof.go
+++ b/rangeproof/proof.go
@@ -16,10 +16,11 @@ import (
 This subpackage of gabi implements a variation of the inequality/range proof protocol given in
 section 6.2.6/6.3.6 of "Specification of the Identity Mixer Cryptographic Library Version 2.3.0".
 
-Specifically, given an attribute m; a value k; and a number a equal to -1 or 1, this subpackage
-allows clients to prove that a(m - k) >= 0, by writing the left hand side as a sum of squares, and
-then proving knowledge of the square roots of these squares. From this, the verifier can infer that
-a(m - k) must be non-negative, i.e. m >= k or m <= k if a = 1 or -1 respectively.
+Specifically, given an attribute m; a value k; a positive number a; and a positive or negative sign
+(i.e. 1 or -1), this subpackage allows clients to prove that sign*(a*m - k) >= 0, by writing the
+left hand side as a sum of squares, and then proving knowledge of the square roots of these squares.
+From this, the verifier can infer that sign*(a*m - k) must be non-negative, i.e. a*m >= k or a*m <=
+k if sign = 1 or -1 respectively.
 
 The following changes were made with respect to the Identity Mixer specification:
 - There is no direct support for the > and < operators: the end user should do boundary adjustment
@@ -30,12 +31,12 @@ The following changes were made with respect to the Identity Mixer specification
 This results in that our code proves the following substatements:
 
     C_i = R^(d_i) S^(v_i)
-    R^(a*k) \product_i C_i^(d_i) = R^(a*m) S^(v_5)
+    R^(sign*k) \product_i C_i^(d_i) = R^(sign*a*m) S^(v_5)
 
 where
 - m is the attribute value,
-- k, a are fixed constants specified in the proof structure,
-- d_i are values such that a(m - k) = \sum_i (d_i)^2,
+- k, a and sign are fixed constants specified in the proof structure,
+- d_i are values such that sign*(a*m - k) = \sum_i (d_i)^2,
 - v_i are computational hiders for the d_i,
 - v_5 = \sum_i d_i * v_i.
 
@@ -106,11 +107,12 @@ Notes:
 */
 
 type (
-	// Statement states that an attribute m satisfies Factor*m-Bound >= 0, and that Factor*m-Bound
-	// can be split into squares with the given Splitter. E.g. if Factor = 1 then m >= k. Defaults to
-	// four square splitter when splitter is not specified.
+	// Statement states that an attribute m satisfies Sign*(Factor*m-Bound) >= 0, and that
+	// Sign*(Factor*m-Bound) can be split into squares with the given Splitter. E.g. if Factor = 1
+	// then Factor*m >= Bound. Defaults to four square splitter when splitter is not specified.
 	Statement struct {
-		Factor   int
+		Sign     int
+		Factor   uint
 		Bound    *big.Int
 		Splitter SquareSplitter
 	}
@@ -122,7 +124,8 @@ type (
 		mCorrect zkproof.QrRepresentationProofStructure
 
 		index int
-		a     int
+		sign  int
+		a     uint
 		k     *big.Int
 
 		splitter SquareSplitter
@@ -138,9 +141,10 @@ type (
 		MResponse  *big.Int   `json:"-"`
 
 		// Proof structure description
-		Ld uint     `json:"l_d"`
-		A  int      `json:"a"`
-		K  *big.Int `json:"k"`
+		Ld   uint     `json:"l_d"`
+		Sign int      `json:"sign"`
+		A    uint     `json:"a"`
+		K    *big.Int `json:"k"`
 	}
 
 	ProofCommit struct {
@@ -174,45 +178,47 @@ var (
 func NewStatement(typ StatementType, bound *big.Int) *Statement {
 	switch typ {
 	case GreaterOrEqual:
-		return &Statement{Factor: 1, Bound: new(big.Int).Set(bound)}
+		return &Statement{Sign: 1, Factor: 1, Bound: new(big.Int).Set(bound)}
 	case LesserOrEqual:
-		return &Statement{Factor: -1, Bound: new(big.Int).Set(bound)}
+		return &Statement{Sign: -1, Factor: 1, Bound: new(big.Int).Set(bound)}
 	default:
 		return nil
 	}
 }
 
-// Create a new proof structure for proving a statement of the form factor(m - bound) >= 0.
+// Create a new proof structure for proving a statement of the form sign(factor*m - bound) >= 0.
 //
 // index specifies the index of the attribute.
 // splitter describes the method used for splitting numbers into sum of squares.
-func NewProofStructure(index, factor int, bound *big.Int, splitter SquareSplitter) (*ProofStructure, error) {
-	if factor != 1 && factor != -1 {
-		return nil, errors.New("factor must be either 1 or -1")
-	}
-
+func NewProofStructure(index, sign int, factor uint, bound *big.Int, splitter SquareSplitter) (*ProofStructure, error) {
 	if splitter == nil {
 		splitter = &FourSquaresSplitter{}
 	}
 
 	if splitter.SquareCount() == 3 {
+		if factor != 1 {
+			return nil, errors.New("factor must be 1")
+		}
 		// Not all numbers can be written as sum of 3 squares, but n for which n == 2 (mod 4) can
-		// so ensure that factor(m-bound) falls into that category
+		// so ensure that factor*m-bound falls into that category
 		factor *= 4
 		bound = new(big.Int).Mul(bound, big.NewInt(4)) // ensure we dont overwrite callers copy of bound
 		bound.Sub(bound, big.NewInt(2))
 	}
 
-	return newWithParams(index, factor, bound, splitter, splitter.SquareCount(), splitter.Ld())
+	return newWithParams(index, sign, factor, bound, splitter, splitter.SquareCount(), splitter.Ld())
 }
 
-func newWithParams(index, a int, k *big.Int, split SquareSplitter, nSplit int, ld uint) (*ProofStructure, error) {
+func newWithParams(index, sign int, a uint, k *big.Int, split SquareSplitter, nSplit int, ld uint) (*ProofStructure, error) {
 	if nSplit > 4 {
 		return nil, errors.New("no support for range proofs with delta split in more than 4 squares")
 	}
+	if sign != 1 && sign != -1 {
+		return nil, errors.New("sign must be either 1 or -1")
+	}
 
 	var exp *big.Int
-	if a > 0 {
+	if sign == 1 {
 		exp = new(big.Int).Neg(k)
 	} else {
 		exp = new(big.Int).Set(k)
@@ -224,11 +230,12 @@ func newWithParams(index, a int, k *big.Int, split SquareSplitter, nSplit int, l
 			},
 			Rhs: []zkproof.RhsContribution{
 				{Base: "S", Secret: "v5", Power: -1},
-				{Base: fmt.Sprintf("R%d", index), Secret: "m", Power: int64(-a)},
+				{Base: fmt.Sprintf("R%d", index), Secret: "m", Power: -int64(a) * int64(sign)},
 			},
 		},
 
 		index: index,
+		sign:  sign,
 		a:     a,
 		k:     new(big.Int).Set(k),
 
@@ -258,17 +265,16 @@ func newWithParams(index, a int, k *big.Int, split SquareSplitter, nSplit int, l
 }
 
 func (statement *Statement) ProofStructure(index int) (*ProofStructure, error) {
-	return NewProofStructure(index, statement.Factor, statement.Bound, statement.Splitter)
+	return NewProofStructure(index, statement.Sign, statement.Factor, statement.Bound, statement.Splitter)
 }
 
 func (s *ProofStructure) CommitmentsFromSecrets(g *gabikeys.PublicKey, m, mRandomizer *big.Int) ([]*big.Int, *ProofCommit, error) {
 	var err error
 
 	d := new(big.Int).Mul(m, big.NewInt(int64(s.a)))
-	if s.a > 0 {
-		d.Sub(d, s.k)
-	} else {
-		d.Add(d, s.k)
+	d.Sub(d, s.k)
+	if s.sign == -1 {
+		d.Neg(d)
 	}
 
 	if d.Sign() < 0 {
@@ -352,9 +358,10 @@ func (s *ProofStructure) BuildProof(commit *ProofCommit, challenge *big.Int) *Pr
 		V5Response: new(big.Int).Add(new(big.Int).Mul(challenge, commit.v5), commit.v5Randomizer),
 		MResponse:  new(big.Int).Add(new(big.Int).Mul(challenge, commit.m), commit.mRandomizer),
 
-		Ld: s.ld,
-		A:  s.a,
-		K:  new(big.Int).Set(s.k),
+		Ld:   s.ld,
+		Sign: s.sign,
+		A:    s.a,
+		K:    new(big.Int).Set(s.k),
 	}
 
 	for i := range commit.c {
@@ -412,17 +419,20 @@ func (s *ProofStructure) CommitmentsFromProof(g *gabikeys.PublicKey, p *Proof, c
 }
 
 // Check whether proof makes required statement
-func (p *Proof) ProvesStatement(a int, k *big.Int) bool {
-	if len(p.Cs) == 3 {
-		a *= 4
-		k = new(big.Int).Mul(k, big.NewInt(4))
-		k.Sub(k, big.NewInt(2))
+func (p *Proof) ProvesStatement(sign int, factor uint, bound *big.Int) bool {
+	if sign != 1 && sign != -1 {
+		return false
 	}
-	return a == p.A && k.Cmp(p.K) == 0
+	if len(p.Cs) == 3 {
+		factor *= 4
+		bound = new(big.Int).Mul(bound, big.NewInt(4))
+		bound.Sub(bound, big.NewInt(2))
+	}
+	return sign == p.Sign && factor == p.A && bound.Cmp(p.K) == 0
 }
 
 func (p *Proof) Proves(statement *Statement) bool {
-	return p.ProvesStatement(statement.Factor, statement.Bound)
+	return p.ProvesStatement(statement.Sign, statement.Factor, statement.Bound)
 }
 
 // Extract proof structure from proof
@@ -434,10 +444,11 @@ func (p *Proof) ExtractStructure(index int, g *gabikeys.PublicKey) (*ProofStruct
 	// p.K >= 2^lm+sizeof(a) is never reasonable since that makes |m*a| < |k|, making
 	//  the proof statement trivial (it either always or never holds)
 	if p.K == nil || p.Ld > g.Params.Lm || len(p.Cs) < 3 || len(p.Cs) > 4 ||
-		p.K.BitLen() > int(g.Params.Lm+strconv.IntSize) {
+		p.K.BitLen() > int(g.Params.Lm+strconv.IntSize) ||
+		(len(p.Cs) == 3 && p.A != 4) {
 		return nil, errors.New("invalid proof")
 	}
-	return newWithParams(index, p.A, p.K, nil, len(p.Cs), p.Ld)
+	return newWithParams(index, p.Sign, p.A, p.K, nil, len(p.Cs), p.Ld)
 }
 
 // ---

--- a/rangeproof/proof.go
+++ b/rangeproof/proof.go
@@ -422,7 +422,7 @@ func (s *ProofStructure) CommitmentsFromProof(g *gabikeys.PublicKey, p *Proof, c
 	return contributions
 }
 
-// Check whether proof makes required statement
+// ProvesStatement returns whether the Proof proves or implies the specified statement.
 func (p *Proof) ProvesStatement(sign int, factor uint, bound *big.Int) bool {
 	if sign != 1 && sign != -1 {
 		return false
@@ -432,9 +432,11 @@ func (p *Proof) ProvesStatement(sign int, factor uint, bound *big.Int) bool {
 		bound = new(big.Int).Mul(bound, big.NewInt(4))
 		bound.Sub(bound, big.NewInt(2))
 	}
-	return sign == p.Sign && factor == p.A && bound.Cmp(p.K) == 0
+	return p.Sign == sign && p.A == factor &&
+		(p.K.Cmp(bound) == 0 || p.K.Cmp(bound) == sign)
 }
 
+// Proves returns whether the Proof proves or implies the specified statement.
 func (p *Proof) Proves(statement *Statement) bool {
 	return p.ProvesStatement(statement.Sign, statement.Factor, statement.Bound)
 }

--- a/rangeproof/rangeproof_test.go
+++ b/rangeproof/rangeproof_test.go
@@ -116,7 +116,7 @@ func (_ *bruteForce4) Ld() uint {
 func testRangeProofWithSplitter(t *testing.T, split rangeproof.SquareSplitter) {
 	g := setupPubkey(t)
 
-	s, err := rangeproof.NewProofStructure(1, 1, big.NewInt(45), split)
+	s, err := rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), split)
 	require.NoError(t, err)
 
 	m := big.NewInt(112)
@@ -127,7 +127,7 @@ func testRangeProofWithSplitter(t *testing.T, split rangeproof.SquareSplitter) {
 	require.NoError(t, err)
 	proof := s.BuildProof(commit, big.NewInt(1234567))
 	assert.True(t, s.VerifyProofStructure(g, proof))
-	assert.True(t, proof.ProvesStatement(1, big.NewInt(45)))
+	assert.True(t, proof.ProvesStatement(1, 1, big.NewInt(45)))
 	proofList := s.CommitmentsFromProof(g, proof, big.NewInt(1234567))
 	assert.Equal(t, secretList, proofList)
 }
@@ -153,7 +153,7 @@ func TestRangeProofUsingSumFourSquareAlg(t *testing.T) {
 func TestRangeProofExtractStructure(t *testing.T) {
 	g := setupPubkey(t)
 
-	s, err := rangeproof.NewProofStructure(1, 1, big.NewInt(45), &bruteForce3{})
+	s, err := rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), &bruteForce3{})
 	require.NoError(t, err)
 
 	m := big.NewInt(112)
@@ -167,7 +167,7 @@ func TestRangeProofExtractStructure(t *testing.T) {
 	s, err = proof.ExtractStructure(1, g)
 	require.NoError(t, err)
 	assert.True(t, s.VerifyProofStructure(g, proof))
-	assert.True(t, proof.ProvesStatement(1, big.NewInt(45)))
+	assert.True(t, proof.ProvesStatement(1, 1, big.NewInt(45)))
 	proofList := s.CommitmentsFromProof(g, proof, big.NewInt(1234567))
 	assert.Equal(t, secretList, proofList)
 
@@ -190,7 +190,7 @@ func TestRangeProofExtractStructure(t *testing.T) {
 func TestRangeProofInvalidStatement(t *testing.T) {
 	g := setupPubkey(t)
 
-	s, err := rangeproof.NewProofStructure(1, 1, big.NewInt(113), &bruteForce3{})
+	s, err := rangeproof.NewProofStructure(1, 1, 1, big.NewInt(113), &bruteForce3{})
 	require.NoError(t, err)
 
 	m := big.NewInt(112)
@@ -223,7 +223,7 @@ func (t *testSplit) Ld() uint {
 func TestRangeProofMisbehavingSplit(t *testing.T) {
 	g := setupPubkey(t)
 
-	s, err := rangeproof.NewProofStructure(1, 1, big.NewInt(45), &testSplit{val: nil, e: errors.New("test"), n: 4, ld: 8})
+	s, err := rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), &testSplit{val: nil, e: errors.New("test"), n: 4, ld: 8})
 	require.NoError(t, err)
 
 	m := big.NewInt(112)
@@ -232,17 +232,17 @@ func TestRangeProofMisbehavingSplit(t *testing.T) {
 	_, _, err = s.CommitmentsFromSecrets(g, m, mRandomizer)
 	assert.Error(t, err)
 
-	s, err = rangeproof.NewProofStructure(1, 1, big.NewInt(45), &testSplit{val: []*big.Int{big.NewInt(512), big.NewInt(512), big.NewInt(512)}, e: nil, n: 3, ld: 8})
+	s, err = rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), &testSplit{val: []*big.Int{big.NewInt(512), big.NewInt(512), big.NewInt(512)}, e: nil, n: 3, ld: 8})
 	require.NoError(t, err)
 	_, _, err = s.CommitmentsFromSecrets(g, m, mRandomizer)
 	assert.Error(t, err)
 
-	s, err = rangeproof.NewProofStructure(1, 1, big.NewInt(45), &testSplit{val: []*big.Int{big.NewInt(1), big.NewInt(1), big.NewInt(1)}, e: nil, n: 4, ld: 8})
+	s, err = rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), &testSplit{val: []*big.Int{big.NewInt(1), big.NewInt(1), big.NewInt(1)}, e: nil, n: 4, ld: 8})
 	require.NoError(t, err)
 	_, _, err = s.CommitmentsFromSecrets(g, m, mRandomizer)
 	assert.Error(t, err)
 
-	s, err = rangeproof.NewProofStructure(1, 1, big.NewInt(45), &testSplit{val: []*big.Int{big.NewInt(1), big.NewInt(1), big.NewInt(1)}, e: nil, n: 3, ld: 8})
+	s, err = rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), &testSplit{val: []*big.Int{big.NewInt(1), big.NewInt(1), big.NewInt(1)}, e: nil, n: 3, ld: 8})
 	require.NoError(t, err)
 	secretList, commit, err := s.CommitmentsFromSecrets(g, m, mRandomizer)
 	require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestRangeProofMisbehavingSplit(t *testing.T) {
 func TestVerifyProofStructure(t *testing.T) {
 	g := setupPubkey(t)
 
-	s, err := rangeproof.NewProofStructure(1, 1, big.NewInt(45), &bruteForce3{})
+	s, err := rangeproof.NewProofStructure(1, 1, 1, big.NewInt(45), &bruteForce3{})
 	require.NoError(t, err)
 
 	m := big.NewInt(112)


### PR DESCRIPTION
This PR splits the rangeproof factor and its sign into two separate parameters: the factor, previously an `int`, is now an `uint`, and when previously a negative integer was passed to instantiate lesser-or-equal proofs, this is now done using a separate new parameter called `sign`.

Additionally: 
* make `rangeproof.Proof.ProvesStatement` also return true if the proof implies the specified inequality: i.e. if `x > y` was proven by the prover, then `ProvesStatement` now also returns true when asked to check `x > y - 1`.
* add `rangeproof.Proof.ProvenStatement()` method to extract from a rangeproof the details of the proven statement.