### PR TITLE
fix: Properly check for ModInverse failure in reconstructZ

### DIFF
--- a/clsignature.go
+++ b/clsignature.go
@@ -104,7 +104,10 @@ func (s *CLSignature) Verify(pk *gabikeys.PublicKey, ms []*big.Int) bool {
 	if s.KeyshareP != nil {
 		R.Mul(R, s.KeyshareP)
 	}
-	Sv := common.ModPow(pk.S, s.V, pk.N)
+	Sv, err := common.ModPow(pk.S, s.V, pk.N)
+	if err != nil {
+		return false
+	}
 	Q := new(big.Int).Mul(Ae, R)
 	Q.Mul(Q, Sv).Mod(Q, pk.N)
 

--- a/credential.go
+++ b/credential.go
@@ -291,12 +291,22 @@ func (d *DisclosureProofBuilder) Commit(randomizers map[string]*big.Int) ([]*big
 
 	// Z = A^{e_commit} * S^{v_commit}
 	//     PROD_{i \in undisclosed} ( R_i^{a_commits{i}} )
-	Ae := common.ModPow(d.randomizedSignature.A, d.eCommit, d.pk.N)
-	Sv := common.ModPow(d.pk.S, d.vCommit, d.pk.N)
+	Ae, err := common.ModPow(d.randomizedSignature.A, d.eCommit, d.pk.N)
+	if err != nil {
+		return nil, err
+	}
+	Sv, err := common.ModPow(d.pk.S, d.vCommit, d.pk.N)
+	if err != nil {
+		return nil, err
+	}
 	d.z.Mul(d.z, Ae).Mul(d.z, Sv).Mod(d.z, d.pk.N)
 
 	for _, v := range d.undisclosedAttributes {
-		d.z.Mul(d.z, common.ModPow(d.pk.R[v], d.attrRandomizers[v], d.pk.N))
+		t, err := common.ModPow(d.pk.R[v], d.attrRandomizers[v], d.pk.N)
+		if err != nil {
+			return nil, err
+		}
+		d.z.Mul(d.z, t)
 		d.z.Mod(d.z, d.pk.N)
 	}
 

--- a/internal/common/mathutil.go
+++ b/internal/common/mathutil.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	mathRand "math/rand"
 
+	"github.com/go-errors/errors"
 	"github.com/privacybydesign/gabi/big"
 )
 
@@ -51,15 +52,17 @@ func ModInverse(a, n *big.Int) (ia *big.Int, ok bool) {
 	return x, true
 }
 
-// modPow computes x^y mod m. The exponent (y) can be negative, in which case it
-// uses the modular inverse to compute the result (in contrast to Go's Exp
-// function).
-func ModPow(x, y, m *big.Int) *big.Int {
+var ErrNoModInverse = errors.New("modular inverse does not exist")
+
+func ModPow(x, y, m *big.Int) (*big.Int, error) {
 	if y.Sign() == -1 {
 		t := new(big.Int).ModInverse(x, m)
-		return t.Exp(t, new(big.Int).Neg(y), m)
+		if t == nil {
+			return nil, ErrNoModInverse
+		}
+		return t.Exp(t, new(big.Int).Neg(y), m), nil
 	}
-	return new(big.Int).Exp(x, y, m)
+	return new(big.Int).Exp(x, y, m), nil
 }
 
 // RepresentToPublicKey returns a representation of the given exponents in terms of the R bases

--- a/internal/common/mathutil.go
+++ b/internal/common/mathutil.go
@@ -54,6 +54,9 @@ func ModInverse(a, n *big.Int) (ia *big.Int, ok bool) {
 
 var ErrNoModInverse = errors.New("modular inverse does not exist")
 
+// ModPow computes x^y mod m. The exponent (y) can be negative, in which case it
+// uses the modular inverse to compute the result (in contrast to Go's Exp
+// function).
 func ModPow(x, y, m *big.Int) (*big.Int, error) {
 	if y.Sign() == -1 {
 		t := new(big.Int).ModInverse(x, m)
@@ -65,7 +68,7 @@ func ModPow(x, y, m *big.Int) (*big.Int, error) {
 	return new(big.Int).Exp(x, y, m), nil
 }
 
-// RepresentToPublicKey returns a representation of the given exponents in terms of the R bases
+// RepresentToBases returns a representation of the given exponents in terms of the R bases
 // from the public key. For example given exponents exps[1],...,exps[k] this function returns
 //   R[1]^{exps[1]}*...*R[k]^{exps[k]} (mod N)
 // with R and N coming from the public key. The exponents are hashed if their length

--- a/issuer.go
+++ b/issuer.go
@@ -94,6 +94,9 @@ func (i *Issuer) proveSignature(signature *CLSignature, nonce2 *big.Int) (*Proof
 	Q := new(big.Int).Exp(signature.A, signature.E, i.Pk.N)
 	groupModulus := new(big.Int).Mul(i.Sk.PPrime, i.Sk.QPrime)
 	d := new(big.Int).ModInverse(signature.E, groupModulus)
+	if d == nil {
+		return nil, common.ErrNoModInverse
+	}
 
 	eCommit, err := randomElementMultiplicativeGroup(groupModulus)
 	if err != nil {

--- a/proofs.go
+++ b/proofs.go
@@ -76,21 +76,33 @@ func (p *ProofU) VerifyWithChallenge(pk *gabikeys.PublicKey, reconstructedChalle
 
 // reconstructUcommit reconstructs U from the information in the proof and the
 // provided public key.
-func (p *ProofU) reconstructUcommit(pk *gabikeys.PublicKey) *big.Int {
+func (p *ProofU) reconstructUcommit(pk *gabikeys.PublicKey) (*big.Int, error) {
 	// Reconstruct Ucommit
 	// U_commit = U^{-C} * S^{VPrimeResponse} * R_0^{SResponse}
-	Uc := common.ModPow(p.U, new(big.Int).Neg(p.C), pk.N)
-	Sv := common.ModPow(pk.S, p.VPrimeResponse, pk.N)
-	R0s := common.ModPow(pk.R[0], p.SResponse, pk.N)
+	Uc, err := common.ModPow(p.U, new(big.Int).Neg(p.C), pk.N)
+	if err != nil {
+		return nil, err
+	}
+	Sv, err := common.ModPow(pk.S, p.VPrimeResponse, pk.N)
+	if err != nil {
+		return nil, err
+	}
+	R0s, err := common.ModPow(pk.R[0], p.SResponse, pk.N)
+	if err != nil {
+		return nil, err
+	}
 	Ucommit := new(big.Int).Mul(Uc, Sv)
 	Ucommit.Mul(Ucommit, R0s).Mod(Ucommit, pk.N)
 
 	for i, miUserResponse := range p.MUserResponses {
-		Rimi := common.ModPow(pk.R[i], miUserResponse, pk.N)
+		Rimi, err := common.ModPow(pk.R[i], miUserResponse, pk.N)
+		if err != nil {
+			return nil, err
+		}
 		Ucommit.Mul(Ucommit, Rimi).Mod(Ucommit, pk.N)
 	}
 
-	return Ucommit
+	return Ucommit, nil
 }
 
 // SecretKeyResponse returns the secret key response (as part of Proof
@@ -107,7 +119,11 @@ func (p *ProofU) Challenge() *big.Int {
 // ChallengeContribution returns the contribution of this proof to the
 // challenge.
 func (p *ProofU) ChallengeContribution(pk *gabikeys.PublicKey) ([]*big.Int, error) {
-	return []*big.Int{p.U, p.reconstructUcommit(pk)}, nil
+	Ucommit, err := p.reconstructUcommit(pk)
+	if err != nil {
+		return nil, err
+	}
+	return []*big.Int{p.U, Ucommit}, nil
 }
 
 // ProofS represents a proof.
@@ -207,17 +223,30 @@ func (p *ProofD) reconstructZ(pk *gabikeys.PublicKey) (*big.Int, error) {
 
 	known := new(big.Int).ModInverse(numerator, pk.N)
 	if known == nil {
-		return nil, errors.Errorf("The numerator and N are not relatively prime")
+		return nil, common.ErrNoModInverse
 	}
 
 	known.Mul(pk.Z, known)
 
-	knownC := common.ModPow(known, new(big.Int).Neg(p.C), pk.N)
-	Ae := common.ModPow(p.A, p.EResponse, pk.N)
-	Sv := common.ModPow(pk.S, p.VResponse, pk.N)
+	knownC, err := common.ModPow(known, new(big.Int).Neg(p.C), pk.N)
+	if err != nil {
+		return nil, err
+	}
+	Ae, err := common.ModPow(p.A, p.EResponse, pk.N)
+	if err != nil {
+		return nil, err
+	}
+	Sv, err := common.ModPow(pk.S, p.VResponse, pk.N)
+	if err != nil {
+		return nil, err
+	}
 	Rs := big.NewInt(1)
 	for i, response := range p.AResponses {
-		Rs.Mul(Rs, common.ModPow(pk.R[i], response, pk.N))
+		t, err := common.ModPow(pk.R[i], response, pk.N)
+		if err != nil {
+			return nil, err
+		}
+		Rs.Mul(Rs, t)
 	}
 	Z := new(big.Int).Mul(knownC, Ae)
 	Z.Mul(Z, Rs).Mul(Z, Sv).Mod(Z, pk.N)


### PR DESCRIPTION
This prevents a panic when verifying a `ProofD` whose `A` has been set to 0.

(Ported from https://github.com/minvws/gabi/pull/6.)