### PR TITLE
Fix too stringent keyshare test

### DIFF
--- a/gabi_test.go
+++ b/gabi_test.go
@@ -947,7 +947,7 @@ func TestKeyshare(t *testing.T) {
 
 	commit, W, err := NewKeyshareCommitments(secret, []*gabikeys.PublicKey{testPubK})
 	require.NoError(t, err)
-	require.Equal(t, uint(commit.BitLen()), gabikeys.DefaultSystemParameters[2048].LmCommit)
+	require.LessOrEqual(t, uint(commit.BitLen()), gabikeys.DefaultSystemParameters[2048].LmCommit)
 
 	response := KeyshareResponse(secret, commit, big.NewInt(123), testPubK)
 	assert.Equal(t, new(big.Int).Exp(testPubK.R[0], response.SResponse, testPubK.N),


### PR DESCRIPTION
The randomizer of zero-knowledge proofs is only required to be less than an upper limit, so we should not require it to have an exact bit length, which effectively also places a lower limit.