### PR TITLE
Increase group sizes used in some keyproof tests to avoid degenerate panics

### DIFF
--- a/keyproof/almostsafeprimeproduct_test.go
+++ b/keyproof/almostsafeprimeproduct_test.go
@@ -9,57 +9,47 @@ import (
 )
 
 func TestAlmostSafePrimeProductCycle(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	listBefore, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := almostSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), big.NewInt(3), commit)
+	listBefore, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := almostSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), big.NewInt(3), commit)
 	require.True(t, almostSafePrimeProductVerifyStructure(proof), "Proof structure rejected")
 
 	listAfter := almostSafePrimeProductExtractCommitments([]*big.Int{}, proof)
 	assert.True(t,
-		almostSafePrimeProductVerifyProof(big.NewInt((2*p+1)*(2*q+1)), big.NewInt(12345), big.NewInt(3), proof),
+		almostSafePrimeProductVerifyProof(testN, big.NewInt(12345), big.NewInt(3), proof),
 		"AlmostSafePrimeProduct rejected")
 	assert.Equal(t, listBefore, listAfter, "Difference between commitments")
 }
 
 func TestAlmostSafePrimeProductCycleIncorrectNonce(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := almostSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), big.NewInt(3), commit)
+	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := almostSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), big.NewInt(3), commit)
 	proof.Nonce.Sub(proof.Nonce, big.NewInt(1))
 	assert.False(t,
-		almostSafePrimeProductVerifyProof(big.NewInt((2*p+1)*(2*q+1)), big.NewInt(12345), big.NewInt(3), proof),
+		almostSafePrimeProductVerifyProof(testN, big.NewInt(12345), big.NewInt(3), proof),
 		"Incorrect AlmostSafePrimeProductProof accepted.")
 }
 
 func TestAlmostSafePrimeProductCycleIncorrectCommitment(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := almostSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), big.NewInt(3), commit)
+	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := almostSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), big.NewInt(3), commit)
 	proof.Commitments[0].Add(proof.Commitments[0], big.NewInt(1))
 	assert.False(t,
-		almostSafePrimeProductVerifyProof(big.NewInt((2*p+1)*(2*q+1)), big.NewInt(12345), big.NewInt(3), proof),
+		almostSafePrimeProductVerifyProof(testN, big.NewInt(12345), big.NewInt(3), proof),
 		"Incorrect AlmostSafePrimeProductProof accepted.")
 }
 
 func TestAlmostSafePrimeProductCycleIncorrectResponse(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := almostSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), big.NewInt(3), commit)
+	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := almostSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), big.NewInt(3), commit)
 	proof.Responses[0].Add(proof.Responses[0], big.NewInt(1))
 	assert.False(t,
-		almostSafePrimeProductVerifyProof(big.NewInt((2*p+1)*(2*q+1)), big.NewInt(12345), big.NewInt(3), proof),
+		almostSafePrimeProductVerifyProof(testN, big.NewInt(12345), big.NewInt(3), proof),
 		"Incorrect AlmostSafePrimeProductProof accepted.")
 }
 
 func TestAlmostSafePrimeProductVerifyStructure(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := almostSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), big.NewInt(3), commit)
+	_, commit := almostSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := almostSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), big.NewInt(3), commit)
 
 	listBackup := proof.Commitments
 	proof.Commitments = proof.Commitments[:len(proof.Commitments)-1]

--- a/keyproof/primeproof_test.go
+++ b/keyproof/primeproof_test.go
@@ -5,22 +5,25 @@ import (
 	"testing"
 
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/safeprime"
 	"github.com/privacybydesign/gabi/zkproof"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrimeProofFlow(t *testing.T) {
-	g, gok := zkproof.BuildGroup(big.NewInt(47))
+	g, gok := zkproof.BuildGroup(testP)
 	require.True(t, gok, "Failed to setup group for Prime proof testing")
 
 	Follower.(*TestFollower).count = 0
 
-	s := newPrimeProofStructure("p", 4)
+	s := newPrimeProofStructure("p", uint(testP.BitLen())-2)
 
-	const p = 11
+	p, err := safeprime.Generate(testP.BitLen()-2, nil)
+	require.NoError(t, err)
+
 	pCommits := newPedersenStructure("p")
-	_, pCommit := pCommits.commitmentsFromSecrets(g, nil, big.NewInt(p))
+	_, pCommit := pCommits.commitmentsFromSecrets(g, nil, p)
 	bases := zkproof.NewBaseMerge(&g, &pCommit)
 
 	listSecrets, commit := s.commitmentsFromSecrets(g, []*big.Int{}, &bases, &pCommit)

--- a/keyproof/quasisafeprimeproduct_test.go
+++ b/keyproof/quasisafeprimeproduct_test.go
@@ -12,24 +12,20 @@ import (
 )
 
 func TestQuasiSafePrimeProductCycle(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	listBefore, commit := quasiSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := quasiSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), commit)
+	listBefore, commit := quasiSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := quasiSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), commit)
 	assert.True(t, quasiSafePrimeProductVerifyStructure(proof), "Proof structure rejected")
 	listAfter := quasiSafePrimeProductExtractCommitments([]*big.Int{}, proof)
-	ok := quasiSafePrimeProductVerifyProof(big.NewInt((2*p+1)*(2*q+1)), big.NewInt(12345), proof)
+	ok := quasiSafePrimeProductVerifyProof(testN, big.NewInt(12345), proof)
 	assert.True(t, ok, "QuasiSafePrimeProduct rejected")
 	assert.Equal(t, listBefore, listAfter, "Difference between commitment lists")
 }
 
 func TestQuasiSafePrimeProductFullCycle(t *testing.T) {
 	// Build proof
-	const p = 13451
-	const q = 13901
-	listBefore, commit := quasiSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
+	listBefore, commit := quasiSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
 	challengeBefore := common.HashCommit(listBefore, false)
-	proofBefore := quasiSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), challengeBefore, commit)
+	proofBefore := quasiSafePrimeProductBuildProof(testPPrime, testQPrime, challengeBefore, commit)
 	proofJSON, err := json.Marshal(proofBefore)
 	require.NoError(t, err, "error during json marshal")
 
@@ -39,15 +35,13 @@ func TestQuasiSafePrimeProductFullCycle(t *testing.T) {
 	require.NoError(t, err, "error during json unmarshal")
 	listAfter := quasiSafePrimeProductExtractCommitments([]*big.Int{}, proofAfter)
 	challengeAfter := common.HashCommit(listAfter, false)
-	ok := quasiSafePrimeProductVerifyProof(big.NewInt((2*p+1)*(2*q+1)), challengeAfter, proofAfter)
+	ok := quasiSafePrimeProductVerifyProof(testN, challengeAfter, proofAfter)
 	assert.True(t, ok, "JSON proof rejected")
 }
 
 func TestQuasiSafePrimeProductVerifyStructure(t *testing.T) {
-	const p = 13451
-	const q = 13901
-	_, commit := quasiSafePrimeProductBuildCommitments([]*big.Int{}, big.NewInt(p), big.NewInt(q))
-	proof := quasiSafePrimeProductBuildProof(big.NewInt(p), big.NewInt(q), big.NewInt(12345), commit)
+	_, commit := quasiSafePrimeProductBuildCommitments([]*big.Int{}, testPPrime, testQPrime)
+	proof := quasiSafePrimeProductBuildProof(testPPrime, testQPrime, big.NewInt(12345), commit)
 
 	valBackup := proof.SFproof.Responses[2]
 	proof.SFproof.Responses[2] = nil

--- a/keyproof/validkeyproof_test.go
+++ b/keyproof/validkeyproof_test.go
@@ -5,122 +5,137 @@ import (
 	"testing"
 
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/safeprime"
 	"github.com/stretchr/testify/assert"
 )
 
+// (Safe) primes to use in tests. Generating these takes a while, so we generate them once
+// and then reuse them across all tests.
+var testP, testQ, testPPrime, testQPrime, testN *big.Int
+
+// We take our test primes to be this big. This size (1) avoids some degenerate cases (e.g.
+// accidentally factoring the modulus n or hitting 0 in Z/nZ) with sufficient probability that they
+// shouldn't occur when executing the tests, and (2) achieves reasonable execution times for the
+// tests.
+const testPrimeSize = 64
+
+func init() {
+	var err error
+	var ok bool
+	for !ok {
+		testP, err = safeprime.Generate(testPrimeSize, nil)
+		if err != nil {
+			panic(err)
+		}
+		testQ, err = safeprime.Generate(testPrimeSize, nil)
+		if err != nil {
+			panic(err)
+		}
+		testPPrime = new(big.Int).Rsh(testP, 1)
+		testQPrime = new(big.Int).Rsh(testQ, 1)
+		ok = CanProve(testPPrime, testQPrime)
+	}
+
+	testN = new(big.Int).Mul(testP, testQ)
+}
+
 func TestValidKeyProof(t *testing.T) {
-	const p = 26903
-	const q = 27803
 	const a = 36
 	const b = 49
 	const c = 64
 
 	Follower.(*TestFollower).count = 0
 
-	s := NewValidKeyProofStructure(big.NewInt(p*q), []*big.Int{big.NewInt(a), big.NewInt(b), big.NewInt(c)})
-	proof := s.BuildProof(big.NewInt((p-1)/2), big.NewInt((q-1)/2))
+	// Generate a proof once and then reuse it across subtests to save time
+	s := NewValidKeyProofStructure(testN, []*big.Int{big.NewInt(a), big.NewInt(b), big.NewInt(c)})
+	proof := s.BuildProof(testPPrime, testQPrime)
 
-	assert.Equal(t, int(Follower.(*TestFollower).count), s.numRangeProofs(), "Logging is off GenerateCommitmentsFromSecrets")
-	Follower.(*TestFollower).count = 0
+	t.Run("Valid", func(t *testing.T) {
+		assert.Equal(t, int(Follower.(*TestFollower).count), s.numRangeProofs(), "Logging is off GenerateCommitmentsFromSecrets")
+		Follower.(*TestFollower).count = 0
 
-	ok := s.VerifyProof(proof)
+		ok := s.VerifyProof(proof)
 
-	assert.Equal(t, int(Follower.(*TestFollower).count), s.numRangeProofs(), "Logging is off on GenerateCommitmentsFromProof")
-	assert.True(t, ok, "Proof rejected.")
-}
+		assert.Equal(t, int(Follower.(*TestFollower).count), s.numRangeProofs(), "Logging is off on GenerateCommitmentsFromProof")
+		assert.True(t, ok, "Proof rejected.")
+	})
 
-func TestValidKeyProofStructure(t *testing.T) {
-	const p = 26903
-	const q = 27803
-	const a = 36
-	const b = 49
-	const c = 64
+	t.Run("Structure", func(t *testing.T) {
+		backup := proof.GroupPrime
+		proof.GroupPrime = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting missing group prime")
 
-	s := NewValidKeyProofStructure(big.NewInt(p*q), []*big.Int{big.NewInt(a), big.NewInt(b), big.NewInt(c)})
-	proof := s.BuildProof(big.NewInt((p-1)/2), big.NewInt((q-1)/2))
+		proof.GroupPrime = big.NewInt(10009)
+		assert.False(t, s.VerifyProof(proof), "Accepting non-safe prime as group prime")
 
-	backup := proof.GroupPrime
-	proof.GroupPrime = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting missing group prime")
+		proof.GroupPrime = big.NewInt(20015)
+		assert.False(t, s.VerifyProof(proof), "Accepting non-prime as group prime")
+		proof.GroupPrime = backup
 
-	proof.GroupPrime = big.NewInt(10009)
-	assert.False(t, s.VerifyProof(proof), "Accepting non-safe prime as group prime")
+		backup = proof.PProof.Commit
+		proof.PProof.Commit = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted PProof")
+		proof.PProof.Commit = backup
 
-	proof.GroupPrime = big.NewInt(20015)
-	assert.False(t, s.VerifyProof(proof), "Accepting non-prime as group prime")
-	proof.GroupPrime = backup
+		backup = proof.QProof.Commit
+		proof.QProof.Commit = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted QProof")
+		proof.QProof.Commit = backup
 
-	backup = proof.PProof.Commit
-	proof.PProof.Commit = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted PProof")
-	proof.PProof.Commit = backup
+		backup = proof.PprimeProof.Commit
+		proof.PprimeProof.Commit = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted PprimeProof")
+		proof.PprimeProof.Commit = backup
 
-	backup = proof.QProof.Commit
-	proof.QProof.Commit = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted QProof")
-	proof.QProof.Commit = backup
+		backup = proof.QprimeProof.Commit
+		proof.QprimeProof.Commit = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted QprimeProof")
+		proof.QprimeProof.Commit = backup
 
-	backup = proof.PprimeProof.Commit
-	proof.PprimeProof.Commit = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted PprimeProof")
-	proof.PprimeProof.Commit = backup
+		backup = proof.PQNRel.Result
+		proof.PQNRel.Result = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted pqnrel")
+		proof.PQNRel.Result = backup
 
-	backup = proof.QprimeProof.Commit
-	proof.QprimeProof.Commit = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted QprimeProof")
-	proof.QprimeProof.Commit = backup
+		backup = proof.Challenge
+		proof.Challenge = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting missing challenge")
 
-	backup = proof.PQNRel.Result
-	proof.PQNRel.Result = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted pqnrel")
-	proof.PQNRel.Result = backup
+		proof.Challenge = big.NewInt(1)
+		assert.False(t, s.VerifyProof(proof), "Accepting incorrect challenge")
+		proof.Challenge = backup
 
-	backup = proof.Challenge
-	proof.Challenge = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting missing challenge")
+		backup = proof.PprimeIsPrimeProof.PreaMod.Result
+		proof.PprimeIsPrimeProof.PreaMod.Result = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted pprimeisprimeproof")
+		proof.PprimeIsPrimeProof.PreaMod.Result = backup
 
-	proof.Challenge = big.NewInt(1)
-	assert.False(t, s.VerifyProof(proof), "Accepting incorrect challenge")
-	proof.Challenge = backup
+		backup = proof.QprimeIsPrimeProof.PreaMod.Result
+		proof.QprimeIsPrimeProof.PreaMod.Result = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted qprimeisprimeproof")
+		proof.QprimeIsPrimeProof.PreaMod.Result = backup
 
-	backup = proof.PprimeIsPrimeProof.PreaMod.Result
-	proof.PprimeIsPrimeProof.PreaMod.Result = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted pprimeisprimeproof")
-	proof.PprimeIsPrimeProof.PreaMod.Result = backup
+		backup = proof.QSPPproof.PPPproof.Responses[2]
+		proof.QSPPproof.PPPproof.Responses[2] = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted QSPPproof")
+		proof.QSPPproof.PPPproof.Responses[2] = backup
 
-	backup = proof.QprimeIsPrimeProof.PreaMod.Result
-	proof.QprimeIsPrimeProof.PreaMod.Result = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted qprimeisprimeproof")
-	proof.QprimeIsPrimeProof.PreaMod.Result = backup
+		backup = proof.BasesValidProof.NProof.Commit
+		proof.BasesValidProof.NProof.Commit = nil
+		assert.False(t, s.VerifyProof(proof), "Accepting corrupted BasesValidProof")
+		proof.BasesValidProof.NProof.Commit = backup
 
-	backup = proof.QSPPproof.PPPproof.Responses[2]
-	proof.QSPPproof.PPPproof.Responses[2] = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted QSPPproof")
-	proof.QSPPproof.PPPproof.Responses[2] = backup
+		assert.True(t, s.VerifyProof(proof), "Testing corrupted proof structure!")
+	})
 
-	backup = proof.BasesValidProof.NProof.Commit
-	proof.BasesValidProof.NProof.Commit = nil
-	assert.False(t, s.VerifyProof(proof), "Accepting corrupted BasesValidProof")
-	proof.BasesValidProof.NProof.Commit = backup
+	t.Run("JSON", func(t *testing.T) {
+		proofJSON, err := json.Marshal(proof)
+		assert.NoError(t, err, "error during json marshal")
 
-	assert.True(t, s.VerifyProof(proof), "Testing corrupted proof structure!")
-}
+		var proofAfter ValidKeyProof
+		err = json.Unmarshal(proofJSON, &proofAfter)
+		assert.NoError(t, err, "error during json unmarshal")
 
-func TestValidKeyProofJSON(t *testing.T) {
-	const p = 26903
-	const q = 27803
-	const a = 36
-	const b = 49
-	const c = 64
-
-	s := NewValidKeyProofStructure(big.NewInt(p*q), []*big.Int{big.NewInt(a), big.NewInt(b), big.NewInt(c)})
-	proofBefore := s.BuildProof(big.NewInt((p-1)/2), big.NewInt((q-1)/2))
-	proofJSON, err := json.Marshal(proofBefore)
-	assert.NoError(t, err, "error during json marshal")
-
-	var proofAfter ValidKeyProof
-	err = json.Unmarshal(proofJSON, &proofAfter)
-	assert.NoError(t, err, "error during json unmarshal")
-
-	assert.True(t, s.VerifyProof(proofAfter), "Proof rejected.")
+		assert.True(t, s.VerifyProof(proofAfter), "Proof rejected.")
+	})
 }


### PR DESCRIPTION
Previously, some tests would accidentally factor the modulus [0] or hit 0 in Z/pZ [1] due to the miniscule group sizes (~100 elements or less) used in the tests, triggering a panic which would cause the test to fail. This commit generates once a set of parameters that is used across the tests to instantiate groups that are still small for speed, but large enough that they should avoid with high probability these degenerate cases.

(NB: This PR leaves `TestPrimeProofFlow` unfixed; that is the last test that still fails sometimes, due to a race condition. https://github.com/privacybydesign/gabi/pull/27 fixes that one.)

[0]: e.g. https://github.com/privacybydesign/gabi/blob/6113e0d3ec8106175ab705187813a37604309c2e/keyproof/squarefree.go#L27
[1]: https://github.com/privacybydesign/gabi/blob/6113e0d3ec8106175ab705187813a37604309c2e/keyproof/primeproof.go#L182