### PR TITLE
Bump fxamacker/cbor to v2.3.0 with secure settings

### DIFF
--- a/cbor/cbor.go
+++ b/cbor/cbor.go
@@ -1,0 +1,89 @@
+// Package cbor provides helper functions for encoding and decoding CBOR
+// by wrapping functions provided by github.com/fxamacker/cbor.
+//
+// 1. CBOR is encoded using Core Deterministic Encoding defined in
+//    RFC 8949, which obsoletes Canonical CBOR defined in RFC 7049.
+// 2. CBOR decoder detects and rejects duplicate map keys, which is
+//    an important requirement in security sensitive applications.
+//
+// For more info, see:
+//   * https://github.com/fxamacker/cbor
+//   * https://github.com/x448/safer-cbor
+//   * https://tools.ietf.org/html/rfc8949
+package cbor
+
+import (
+	"io"
+
+	"github.com/fxamacker/cbor/v2" // imports as cbor
+)
+
+const MaxArrayElements = 1024 * 256
+const MaxMapPairs = 1024 * 256
+
+var (
+	// encOptions specifies how CBOR should be encoded.
+	encOptions = cbor.EncOptions{
+		// Enable encoding options required by Core Deterministic Encoding
+		// See https://datatracker.ietf.org/doc/html/rfc8949#section-4.2.1
+		InfConvert:    cbor.InfConvertFloat16,
+		IndefLength:   cbor.IndefLengthForbidden,
+		NaNConvert:    cbor.NaNConvert7e00,
+		ShortestFloat: cbor.ShortestFloat16,
+		Sort:          cbor.SortCoreDeterministic,
+
+		// We don't use tags
+		TagsMd: cbor.TagsForbidden,
+	}
+
+	// decOptions specifies how CBOR should be decoded.
+	decOptions = cbor.DecOptions{
+		// Core Deterministic decoding options
+		IndefLength: cbor.IndefLengthForbidden,
+
+		// Sanity checks on maps and arrays
+		DupMapKey:        cbor.DupMapKeyEnforcedAPF,
+		MaxArrayElements: MaxArrayElements,
+		MaxMapPairs:      MaxMapPairs,
+
+		// We don't use tags
+		TagsMd:  cbor.TagsForbidden,
+		TimeTag: cbor.DecTagIgnored,
+
+		// Don't set ExtraDecErrorUnknownField: we allow extra fields for forward compatibility
+		ExtraReturnErrors: cbor.ExtraDecErrorNone,
+	}
+
+	encMode cbor.EncMode
+	decMode cbor.DecMode
+)
+
+func init() {
+	var err error
+	if encMode, err = encOptions.EncMode(); err != nil {
+		panic(err)
+	}
+	if decMode, err = decOptions.DecMode(); err != nil {
+		panic(err)
+	}
+}
+
+// Marshal encodes src into a CBOR-encoded byte slice.
+func Marshal(src interface{}) ([]byte, error) {
+	return encMode.Marshal(src)
+}
+
+// Unmarshal decodes CBOR in data into dst.
+func Unmarshal(data []byte, dst interface{}) error {
+	return decMode.Unmarshal(data, dst)
+}
+
+// NewEncoder creates a new CBOR encoder that writes to w.
+func NewEncoder(w io.Writer) *cbor.Encoder {
+	return encMode.NewEncoder(w)
+}
+
+// NewDecoder creates a new CBOR decoder that reads from r.
+func NewDecoder(r io.Reader) *cbor.Decoder {
+	return decMode.NewDecoder(r)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,12 @@ go 1.13
 
 require (
 	github.com/bwesterb/go-exptable v1.0.0
-	github.com/fxamacker/cbor v1.5.0
+	github.com/fxamacker/cbor/v2 v2.3.0
 	github.com/go-errors/errors v1.0.1
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/multiformats/go-multihash v0.0.11
 	github.com/sirupsen/logrus v1.4.2
-	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1
-	github.com/x448/float16 v0.8.4
-	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
-	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d // indirect
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
 github.com/bwesterb/go-exptable v1.0.0 h1:23PSZOb/63bD1WOkCwBDNC5lI+CgziLSXis9aId334k=
 github.com/bwesterb/go-exptable v1.0.0/go.mod h1:g2X3srHVojy70H73yL0Wxy0yuuMuJwJByeKXaBkEZpw=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor v1.5.0 h1:idAiyeNSq/jeG9FPbCLVZLFJjsxP+g40a3UrXFapumw=
-github.com/fxamacker/cbor v1.5.0/go.mod h1:UjdWSysJckWsChYy9I5zMbkGvK4xXDR+LmDb8kPGYgA=
+github.com/fxamacker/cbor/v2 v2.3.0 h1:aM45YGMctNakddNNAezPxDUpv38j44Abh+hifNuqXik=
+github.com/fxamacker/cbor/v2 v2.3.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -30,7 +29,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/x448/float16 v0.8.3/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -44,6 +42,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/revocation/api.go
+++ b/revocation/api.go
@@ -71,13 +71,14 @@ import (
 	"sort"
 	"time"
 
-	"github.com/fxamacker/cbor"
-	"github.com/go-errors/errors"
-	"github.com/multiformats/go-multihash"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/cbor"
 	"github.com/privacybydesign/gabi/gabikeys"
 	"github.com/privacybydesign/gabi/internal/common"
 	"github.com/privacybydesign/gabi/signed"
+
+	"github.com/go-errors/errors"
+	"github.com/multiformats/go-multihash"
 	"github.com/sirupsen/logrus"
 )
 
@@ -283,7 +284,7 @@ func (update *Update) UnmarshalJSON(bts []byte) error {
 }
 
 func (update *Update) MarshalCBOR() ([]byte, error) {
-	return cbor.Marshal(update.compress(), cbor.EncOptions{})
+	return cbor.Marshal(update.compress())
 }
 
 func (update *Update) UnmarshalCBOR(data []byte) error {
@@ -445,7 +446,7 @@ func (el *EventList) UnmarshalJSON(bts []byte) error {
 }
 
 func (el *EventList) MarshalCBOR() ([]byte, error) {
-	return cbor.Marshal(el.compress(), cbor.EncOptions{})
+	return cbor.Marshal(el.compress())
 }
 
 func (el *EventList) UnmarshalCBOR(bts []byte) error {

--- a/signed/signed.go
+++ b/signed/signed.go
@@ -15,7 +15,8 @@ import (
 	"encoding/pem"
 	"math/big"
 
-	"github.com/fxamacker/cbor"
+	"github.com/privacybydesign/gabi/cbor"
+
 	"github.com/go-errors/errors"
 )
 
@@ -123,7 +124,7 @@ func MarshalSign(sk *ecdsa.PrivateKey, message interface{}) (Message, error) {
 	var err error
 
 	// marshal message to []byte
-	bts, err := cbor.Marshal(message, cbor.EncOptions{})
+	bts, err := cbor.Marshal(message)
 
 	// sign message []byte
 	signature, err := Sign(sk, bts)
@@ -132,7 +133,7 @@ func MarshalSign(sk *ecdsa.PrivateKey, message interface{}) (Message, error) {
 	}
 
 	// encode and return message-signature pair
-	return cbor.Marshal(&tuple{bts, signature}, cbor.EncOptions{})
+	return cbor.Marshal(&tuple{bts, signature})
 }
 
 // UnmarshalVerify verifies the signature a Message created by MarshalSign, and unmarshals the


### PR DESCRIPTION
Port of https://github.com/privacybydesign/irmago/pull/157 to here, since we use CBOR here as well. Once this is merged, `irmago` should use the new CBOR subpackage from here.

Bump fxamacker/cbor to v2.3.0 and create internal/cbor/cbor.go to wrap CBOR functions using secure options. 

CBOR is encoded using Core Deterministic Encoding defined in RFC 8949, which obsoletes Canonical CBOR defined in RFC 7049.  Old decoders will still be able to decode newly encoded data.

- [x] bump fxamacker/cbor from v1.5 to v2.3 to benefit from bug fixes and speedups
 - [x] improve security of CBOR serialization by creating and using internal/cbor/cbor.go
     - [x] encoding -- use Core Deterministic Encoding with indefinite length items disabled
     - [x] decoding -- detect and reject duplicate map keys when decoding CBOR, reject indefinite length items
     
Limit on max array elements can be increased if they're too small.

```Go
// irmago/internal/cbor/cbor.go 
const MaxArrayElements = 1024 * 256 // this limit can be set as high as 2147483647
const MaxMapPairs = 1024 * 256      // this limit can be set as high as 2147483647
```
