### PR TITLE
Improve safeprime.Generate() algorithm

### DIFF
--- a/internal/common/randomprime.go
+++ b/internal/common/randomprime.go
@@ -12,20 +12,20 @@ import (
 	"github.com/privacybydesign/gabi/big"
 )
 
-// smallPrimes is a list of small, prime numbers that allows us to rapidly
+// SmallPrimes is a list of small, prime numbers that allows us to rapidly
 // exclude some fraction of composite candidates when searching for a random
-// prime. This list is truncated at the point where smallPrimesProduct exceeds
+// prime. This list is truncated at the point where SmallPrimesProduct exceeds
 // a uint64. It does not include two because we ensure that the candidates are
 // odd by construction.
-var smallPrimes = []uint8{
+var SmallPrimes = []uint8{
 	3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
 }
 
-// smallPrimesProduct is the product of the values in smallPrimes and allows us
+// SmallPrimesProduct is the product of the values in SmallPrimes and allows us
 // to reduce a candidate prime by this number and then determine whether it's
-// coprime to all the elements of smallPrimes without further big.Int
+// coprime to all the elements of SmallPrimes without further big.Int
 // operations.
-var smallPrimesProduct = new(big.Int).SetUint64(16294579238595022365)
+var SmallPrimesProduct = new(big.Int).SetUint64(16294579238595022365)
 
 // RandomPrimeInRange returns a random probable prime in the range [2^start, 2^start + 2^length]
 // This code is an adaption of Go's own Prime function in rand/util.go
@@ -66,17 +66,17 @@ func RandomPrimeInRange(rand io.Reader, start, length uint) (p *big.Int, err err
 
 		p.Add(startVal, offset)
 
-		// Calculate the value mod the product of smallPrimes.  If it's
+		// Calculate the value mod the product of SmallPrimes.  If it's
 		// a multiple of any of these primes we add two until it isn't.
 		// The probability of overflowing is minimal and can be ignored
 		// because we still perform Miller-Rabin tests on the result.
-		bigMod.Mod(p, smallPrimesProduct)
+		bigMod.Mod(p, SmallPrimesProduct)
 		mod := bigMod.Uint64()
 
 	NextDelta:
 		for delta := uint64(0); delta < 1<<20; delta += 2 {
 			m := mod + delta
-			for _, prime := range smallPrimes {
+			for _, prime := range SmallPrimes {
 				if m%uint64(prime) == 0 && (start > 6 || m != uint64(prime)) {
 					continue NextDelta
 				}

--- a/safeprime/safeprime.go
+++ b/safeprime/safeprime.go
@@ -66,9 +66,9 @@ func GenerateConcurrent(bitsize int, stop chan struct{}) (<-chan *big.Int, <-cha
 //     If (and only if) q is prime and 2^(2q) = 1 mod (2q+1), then 2q+1 is a safe prime.
 // The algorithm works as follows:
 //   - We take a random bigint q;
-//   - We do some bit manipulation to ensure that it has the right size and is not even;
-//   - We sieve out a number of small prime factors: we add 2 to it until it is not a multiple of
-//     any prime below and including 53;
+//   - We do some bit manipulation to ensure that q has the right size and is odd;
+//   - We sieve out some small prime factors: We discard q if it is a multiple of any prime below
+//     and including 53;
 //   - Then, if the above formula holds and q is prime, we return 2q+1.
 // (See https://groups.google.com/group/sci.crypt/msg/34c4abf63568a8eb and below.)
 //

--- a/safeprime/safeprime.go
+++ b/safeprime/safeprime.go
@@ -5,10 +5,12 @@ package safeprime
 
 import (
 	"crypto/rand"
+	"io"
 	"runtime"
 
 	"github.com/go-errors/errors"
 	"github.com/privacybydesign/gabi/big"
+	"github.com/privacybydesign/gabi/internal/common"
 )
 
 // GenerateConcurrent concurrently and continuously generates safeprimes on all CPU cores,
@@ -62,7 +64,12 @@ func GenerateConcurrent(bitsize int, stop chan struct{}) (<-chan *big.Int, <-cha
 
 // Generate a safe prime of the given size, using the fact that:
 //     If (and only if) q is prime and 2^(2q) = 1 mod (2q+1), then 2q+1 is a safe prime.
-// We take a random bigint q; if the above formula holds and q is prime, then we return 2q+1.
+// The algorithm works as follows:
+//   - We take a random bigint q;
+//   - We do some bit manipulation to ensure that it has the right size and is not even;
+//   - We sieve out a number of small prime factors: we add 2 to it until it is not a multiple of
+//     any prime below and including 53;
+//   - Then, if the above formula holds and q is prime, we return 2q+1.
 // (See https://groups.google.com/group/sci.crypt/msg/34c4abf63568a8eb and below.)
 //
 // In order to cancel the generation algorithm, send a struct{} on the stop parameter or close() it.
@@ -71,15 +78,27 @@ func Generate(bitsize int, stop chan struct{}) (*big.Int, error) {
 	var (
 		one        = big.NewInt(1)
 		two        = big.NewInt(2)
-		max        = new(big.Int).Lsh(one, uint(bitsize)) // 2^bitsize, len bitsize+1
 		twoq       = new(big.Int)
 		twoqone    = new(big.Int)
 		twoexptwoq = new(big.Int)
-		q          *big.Int
-		bitlen     int
+		q          = new(big.Int)
+		bigMod     = new(big.Int)
 		err        error
 		i          int
 	)
+
+	// The algorithm generates a prime q and then returns 2q+1. The latter must have length bitsize,
+	// so the former must be one bit shorter.
+	bitsize--
+
+	// b is the number of bits in the most significant byte of the output that will be part of our q
+	b := uint(bitsize % 8)
+	if b == 0 {
+		b = 8
+	}
+
+	// We read our random bytes into this. Adding 7 effectively rounds the division up instead of down
+	bytes := make([]byte, (bitsize+7)/8)
 
 	for {
 		// Every 1000 iterations, check if we have been asked to stop
@@ -92,31 +111,68 @@ func Generate(bitsize int, stop chan struct{}) (*big.Int, error) {
 			}
 		}
 
-		if q, err = big.RandInt(rand.Reader, max); err != nil {
+		// The bit manipulation and the repeated adding of two below is copied from rand.Prime()
+		// in crypto/rand/util.go from Go 1.16.5.
+
+		_, err = io.ReadFull(rand.Reader, bytes)
+		if err != nil {
 			return nil, err
 		}
 
-		bitlen = q.BitLen() // q < max = 2^bitsize, so bitlen <= bitsize
+		// Clear bits in the first byte to make sure the candidate has a size <= bitsize.
+		bytes[0] &= uint8(int(1<<b) - 1)
+		// Don't let the value be too small, i.e, set the most significant two bits.
+		// Setting the top two bits, rather than just the top bit,
+		// means that when two of these values are multiplied together,
+		// the result isn't ever one bit short.
+		if b >= 2 {
+			bytes[0] |= 3 << (b - 2)
+		} else {
+			// Here b==1, because b cannot be zero.
+			bytes[0] |= 1
+			if len(bytes) > 1 {
+				bytes[1] |= 0x80
+			}
+		}
+		// Make the value odd since an even number this large certainly isn't prime.
+		bytes[len(bytes)-1] |= 1
 
-		if q.Bit(0) != uint(1) || // q is not odd
-			bitlen < int(bitsize)-1 { // q is too small
+		q.SetBytes(bytes)
+
+		// Calculate the value mod the product of smallPrimes. If it's
+		// a multiple of any of these primes we add two until it isn't.
+		// The probability of overflowing is minimal and can be ignored
+		// because we still perform Miller-Rabin tests on the result.
+		bigMod.Mod(q, common.SmallPrimesProduct)
+		mod := bigMod.Uint64()
+
+	NextDelta:
+		for delta := uint64(0); delta < 1<<20; delta += 2 {
+			m := mod + delta
+			for _, prime := range common.SmallPrimes {
+				if m%uint64(prime) == 0 && (bitsize > 6 || m != uint64(prime)) {
+					continue NextDelta
+				}
+			}
+
+			if delta > 0 {
+				bigMod.SetUint64(delta)
+				q.Add(q, bigMod)
+			}
+			break
+		}
+
+		// Adding delta may have caused q to become too large
+		if q.BitLen() != bitsize {
 			continue
 		}
 
-		// bitlen now equals either bitsize or bitsize - 1. We want the latter.
-		// If bitlen == bitsize we use (q-1)/2 instead of q in the remainder of the algorithm.
-		// This way the acceptable bit length range of big.RandInt's output is 2 bits.
-		if bitlen == int(bitsize) {
-			q.Rsh(q, 1)
-			if q.Bit(0) != uint(1) { // ensure again that q is odd
-				continue
-			}
-		}
+		// end of copy from crypto/rand/util.go
 
+		// Now check the formula 2^(2q) mod (2q+1) == 1
 		twoq.Mul(two, q)
 		twoqone.Add(twoq, one)
 		twoexptwoq.Exp(two, twoq, twoqone) // 2^(2q) mod (2q+1)
-
 		if twoexptwoq.Cmp(one) == 0 && q.ProbablyPrime(40) {
 			break
 		}


### PR DESCRIPTION
Instead of throwing away candidates that are too small or large or even, this commit makes them appropriate using bit manipulation. Additionally, small factors are removed by repeatedly adding two, before actually checking if the candidate is a safe prime.