### PR TITLE
Fix some typos and warnings

### DIFF
--- a/big/int.go
+++ b/big/int.go
@@ -53,7 +53,7 @@ func (i *Int) MarshalText() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler. If the input is quoted it attempts a
-// base64 -> []byte -> Int conversion using i.SetBytes(). Otherwise it attempts to
+// base64 -> []byte -> Int conversion using i.SetBytes(). Otherwise, it attempts to
 // unmarshal the input as a JSON base 10 big integer.
 func (i *Int) UnmarshalJSON(b []byte) error {
 	if b[0] != '"' { // Not a JSON string, try to decode an ordinarily base-10 encoded "math.big".Int
@@ -87,7 +87,7 @@ func Convert(x *big.Int) *Int {
 	return (*Int)(x)
 }
 
-// Convert to a "math/big".Int
+// Go converts "gabi/big".Int to a "math/big".Int
 func (i *Int) Go() *big.Int {
 	return (*big.Int)(i)
 }

--- a/builder.go
+++ b/builder.go
@@ -29,8 +29,8 @@ type IssueCommitmentMessage struct {
 // UnmarshalJSON implements json.Unmarshaler (json's default unmarshaler
 // is unable to handle a list of interfaces).
 func (pl *ProofList) UnmarshalJSON(bytes []byte) error {
-	proofs := []Proof{}
-	temp := []json.RawMessage{}
+	var proofs []Proof
+	var temp []json.RawMessage
 	if err := json.Unmarshal(bytes, &temp); err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (pl *ProofList) UnmarshalJSON(bytes []byte) error {
 }
 
 // IssueSignatureMessage encapsulates the messages sent from the issuer to the
-// reciver in the final step of the issuance protocol.
+// receiver in the final step of the issuance protocol.
 type IssueSignatureMessage struct {
 	Proof                *ProofS             `json:"proof"`
 	Signature            *CLSignature        `json:"signature"`
@@ -80,7 +80,7 @@ func userCommitment(pk *gabikeys.PublicKey, secret *big.Int, vPrime *big.Int, ms
 
 // NewCredentialBuilder creates a new credential builder.
 // The resulting credential builder is already committed to the provided secret.
-// arg blind: list of indices of random blind attributes (exlcuding the secret key)
+// arg blind: list of indices of random blind attributes (excluding the secret key)
 func NewCredentialBuilder(pk *gabikeys.PublicKey, context, secret *big.Int, nonce2 *big.Int, blind []int) (*CredentialBuilder, error) {
 	vPrime, err := common.RandomBigInt(pk.Params.LvPrime)
 	if err != nil {
@@ -123,13 +123,13 @@ func (b *CredentialBuilder) CommitToSecretAndProve(nonce1 *big.Int) (*IssueCommi
 }
 
 // CreateIssueCommitmentMessage creates the IssueCommitmentMessage based on the
-// provided prooflist, to be sent to the issuer.
+// provided ProofList, to be sent to the issuer.
 func (b *CredentialBuilder) CreateIssueCommitmentMessage(proofs ProofList) *IssueCommitmentMessage {
 	return &IssueCommitmentMessage{U: b.u, Proofs: proofs, Nonce2: b.nonce2}
 }
 
 var (
-	// ErrIncorrectProofOfSignatureCorrectness is issued when the the proof of
+	// ErrIncorrectProofOfSignatureCorrectness is issued when the proof of
 	// correctness on the signature does not verify.
 	ErrIncorrectProofOfSignatureCorrectness = errors.New("Proof of correctness on signature does not verify.")
 	// ErrIncorrectAttributeSignature is issued when the signature on the

--- a/clsignature.go
+++ b/clsignature.go
@@ -31,7 +31,7 @@ type CLSignature struct {
 }
 
 // SignMessageBlock signs a message block (ms) and a commitment (U) using the
-// Camenisch-Lysyanskaya signature scheme as used in the IdeMix system.
+// Camenisch-Lysyanskaya signature scheme as used in the Idemix system.
 func signMessageBlockAndCommitment(sk *gabikeys.PrivateKey, pk *gabikeys.PublicKey, U *big.Int, ms []*big.Int) (
 	*CLSignature, error) {
 	R, err := RepresentToPublicKey(pk, ms)
@@ -75,7 +75,7 @@ func signMessageBlockAndCommitment(sk *gabikeys.PrivateKey, pk *gabikeys.PublicK
 }
 
 // SignMessageBlock signs a message block (ms) using the Camenisch-Lysyanskaya
-// signature scheme as used in the IdeMix system.
+// signature scheme as used in the Idemix system.
 func SignMessageBlock(sk *gabikeys.PrivateKey, pk *gabikeys.PublicKey, ms []*big.Int) (*CLSignature, error) {
 	return signMessageBlockAndCommitment(sk, pk, big.NewInt(1), ms)
 }

--- a/credential.go
+++ b/credential.go
@@ -105,7 +105,7 @@ func isUndisclosedAttribute(disclosedAttributes []int, attribute int) bool {
 	return true
 }
 
-// CreateDisclosureProof creates a disclosure proof (ProofD) voor the provided
+// CreateDisclosureProof creates a disclosure proof (ProofD) for the provided
 // indices of disclosed attributes.
 func (ic *Credential) CreateDisclosureProof(
 	disclosedAttributes []int,
@@ -208,7 +208,7 @@ func (ic *Credential) nonrevConsumeBuilder() (*NonRevocationProofBuilder, error)
 	}
 }
 
-// NonrevPrepareCache ensures that the Credential's nonrevocation proof builder cache is
+// NonrevPrepareCache ensures that the Credential's non-revocation proof builder cache is
 // usable, by creating one if it does not exist, or otherwise updating it to the latest accumulator
 // contained in the credential's witness.
 func (ic *Credential) NonrevPrepareCache() error {
@@ -242,7 +242,7 @@ func (ic *Credential) NonrevPrepareCache() error {
 	return err
 }
 
-// NonrevBuildProofBuilder builds and returns a new commited-to NonRevocationProofBuilder.
+// NonrevBuildProofBuilder builds and returns a new committed-to NonRevocationProofBuilder.
 func (ic *Credential) NonrevBuildProofBuilder() (*NonRevocationProofBuilder, error) {
 	if ic.NonRevocationWitness == nil {
 		return nil, errors.New("credential has no nonrevocation witness")
@@ -397,7 +397,7 @@ func (d *DisclosureProofBuilder) CreateProof(challenge *big.Int) Proof {
 // TimestampRequestContributions returns the contributions of this disclosure proof
 // to the message that is to be signed by the timestamp server:
 // - A of the randomized CL-signature
-// - Slice of bigints populated with the disclosed attributes and 0 for the undisclosed ones.
+// - Slice of big.Int populated with the disclosed attributes and 0 for the undisclosed ones.
 func (d *DisclosureProofBuilder) TimestampRequestContributions() (*big.Int, []*big.Int) {
 	zero := big.NewInt(0)
 	disclosed := make([]*big.Int, len(d.attributes))
@@ -410,7 +410,7 @@ func (d *DisclosureProofBuilder) TimestampRequestContributions() (*big.Int, []*b
 	return d.randomizedSignature.A, disclosed
 }
 
-// Generate secret attribute used prove ownership and links between credentials from the same user.
+// GenerateSecretAttribute generates secret attribute used prove ownership and links between credentials from the same user.
 func GenerateSecretAttribute() (*big.Int, error) {
 	return common.RandomBigInt(gabikeys.DefaultSystemParameters[1024].Lm)
 }

--- a/gabi_test.go
+++ b/gabi_test.go
@@ -573,8 +573,8 @@ func TestGenerateKeyPair(t *testing.T) {
 		Lstatzk: 80,
 	}
 	gabikeys.DefaultSystemParameters[256] = &gabikeys.SystemParameters{
-		base,
-		gabikeys.MakeDerivedParameters(base),
+		BaseParameters:    base,
+		DerivedParameters: gabikeys.MakeDerivedParameters(base),
 	}
 
 	// Using the toy parameters, generate a bunch of keys

--- a/gabi_test.go
+++ b/gabi_test.go
@@ -592,14 +592,6 @@ func TestGenerateKeyPair(t *testing.T) {
 	//testPublicKey(t, pubk, privk)
 }
 
-func genRandomIssuer(t *testing.T, context *big.Int) *Issuer {
-	// TODO: key pair generation is slow, consider caching or providing key material
-	keylength := 1024
-	privk, pubk, err := gabikeys.GenerateKeyPair(gabikeys.DefaultSystemParameters[keylength], 6, 0, time.Now().AddDate(1, 0, 0))
-	assert.NoError(t, err, "error generating key pair")
-	return NewIssuer(privk, pubk, context)
-}
-
 func createCredential(t *testing.T, context, secret *big.Int, issuer *Issuer) *Credential {
 	// First create a credential
 	keylength := 1024

--- a/gabikeys/keys.go
+++ b/gabikeys/keys.go
@@ -88,7 +88,7 @@ func NewPrivateKey(p, q *big.Int, ecdsa string, counter uint, expiryDate time.Ti
 	return &sk, nil
 }
 
-// NewPrivateKeyFromXML creates a new issuer private key using the xml data
+// NewPrivateKeyFromXML creates a new issuer private key using the XML data
 // provided.
 func NewPrivateKeyFromXML(xmlInput string, demo bool) (*PrivateKey, error) {
 	privk := &PrivateKey{}
@@ -113,7 +113,7 @@ func NewPrivateKeyFromXML(xmlInput string, demo bool) (*PrivateKey, error) {
 	return privk, nil
 }
 
-// NewPrivateKeyFromFile create a new issuer private key from an xml file.
+// NewPrivateKeyFromFile creates a new issuer private key from an XML file.
 func NewPrivateKeyFromFile(filename string, demo bool) (*PrivateKey, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -159,7 +159,7 @@ func (privk *PrivateKey) WriteTo(writer io.Writer) (int64, error) {
 		return 0, err
 	}
 
-	// And the actual xml body (with indentation)
+	// And the actual XML body (with indentation)
 	b, err := xml.MarshalIndent(privk, "", "   ")
 	if err != nil {
 		return int64(numHeaderBytes), err
@@ -168,7 +168,7 @@ func (privk *PrivateKey) WriteTo(writer io.Writer) (int64, error) {
 	return int64(numHeaderBytes + numBodyBytes), err
 }
 
-// WriteToFile writes the private key to an xml file. If any existing file with
+// WriteToFile writes the private key to an XML file. If any existing file with
 // the same filename should be overwritten, set forceOverwrite to true.
 func (privk *PrivateKey) WriteToFile(filename string, forceOverwrite bool) (int64, error) {
 	var f *os.File
@@ -257,7 +257,7 @@ func NewPublicKey(N, Z, S, G, H *big.Int, R []*big.Int, ecdsa string, counter ui
 	return pk, nil
 }
 
-// NewPublicKeyFromXML creates a new issuer public key using the xml data
+// NewPublicKeyFromBytes creates a new issuer public key using the XML data
 // provided.
 func NewPublicKeyFromBytes(bts []byte) (*PublicKey, error) {
 	// TODO: this might fail in the future. The DefaultSystemParameters and the
@@ -283,7 +283,7 @@ func NewPublicKeyFromXML(xmlInput string) (*PublicKey, error) {
 	return NewPublicKeyFromBytes([]byte(xmlInput))
 }
 
-// NewPublicKeyFromFile create a new issuer public key from an xml file.
+// NewPublicKeyFromFile creates a new issuer public key from an XML file.
 func NewPublicKeyFromFile(filename string) (*PublicKey, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -342,7 +342,7 @@ func (pubk *PublicKey) WriteTo(writer io.Writer) (int64, error) {
 		return 0, err
 	}
 
-	// And the actual xml body (with indentation)
+	// And the actual XML body (with indentation)
 	b, err := xml.MarshalIndent(pubk, "", "   ")
 	if err != nil {
 		return int64(numHeaderBytes), err
@@ -351,7 +351,7 @@ func (pubk *PublicKey) WriteTo(writer io.Writer) (int64, error) {
 	return int64(numHeaderBytes + numBodyBytes), err
 }
 
-// WriteToFile writes the public key to an xml file. If any existing file with
+// WriteToFile writes the public key to an XML file. If any existing file with
 // the same filename should be overwritten, set forceOverwrite to true.
 func (pubk *PublicKey) WriteToFile(filename string, forceOverwrite bool) (int64, error) {
 	var f *os.File
@@ -388,22 +388,22 @@ func generateSafePrimePair(param *SystemParameters) (*big.Int, *big.Int, error) 
 
 	// Declare and allocate all vars outside the loop and outside the helper function above
 	stop := make(chan struct{})
-	safeprimes := make([]*big.Int, 0, 10) // store all generated safeprimes until we find a suitable pair
+	safeprimes := make([]*big.Int, 0, 10) // store all generated safe primes until we find a suitable pair
 	pPrime, pPrimeMod8, pMod8, qMod8, n := new(big.Int), new(big.Int), new(big.Int), new(big.Int), new(big.Int)
 	var p, q *big.Int
 	var err error
 
-	// Start generating safeprimes
+	// Start generating safe primes
 	ints, errs := safeprime.GenerateConcurrent(int(primeSize), stop)
 
-	// Receive safeprime results in a loop, until we have a suitable pair of safeprimes.
+	// Receive safe prime results in a loop, until we have a suitable pair of safe primes.
 loop: // we need this label to continue the for loop from within the select below
 	for {
 		select { // wait for and then handle an incoming bigint or error, whichever comes first
 
 		case p = <-ints:
 			pPrimeMod8.Mod(pPrime.Rsh(p, 1), big.NewInt(8))
-			// p is our candidate safeprime, set p' = (p-1)/2. Check that p' mod 8 != 1
+			// p is our candidate safe prime, set p' = (p-1)/2. Check that p' mod 8 != 1
 			if pPrimeMod8.Cmp(big.NewInt(1)) == 0 {
 				continue loop
 			}
@@ -416,7 +416,7 @@ loop: // we need this label to continue the for loop from within the select belo
 			return p, q, nil
 
 		case err = <-errs:
-			close(stop) // Something went wrong during safeprime generation, abort
+			close(stop) // Something went wrong during safe prime generation, abort
 			return nil, nil, err
 
 		}

--- a/gabikeys/keys.go
+++ b/gabikeys/keys.go
@@ -119,7 +119,7 @@ func NewPrivateKeyFromFile(filename string, demo bool) (*PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer common.Close(f)
 
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
@@ -182,7 +182,7 @@ func (privk *PrivateKey) WriteToFile(filename string, forceOverwrite bool) (int6
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer common.Close(f)
 
 	return privk.WriteTo(f)
 }
@@ -289,7 +289,7 @@ func NewPublicKeyFromFile(filename string) (*PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer common.Close(f)
 	pubk := &PublicKey{}
 
 	b, err := ioutil.ReadAll(f)
@@ -365,7 +365,7 @@ func (pubk *PublicKey) WriteToFile(filename string, forceOverwrite bool) (int64,
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer common.Close(f)
 
 	return pubk.WriteTo(f)
 }

--- a/gabikeys/marshaling.go
+++ b/gabikeys/marshaling.go
@@ -44,7 +44,7 @@ func (bl *Bases) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		arr[i], _ = new(big.Int).SetString(t.Bases[i].Bigint, 10)
 	}
 
-	*bl = Bases(arr)
+	*bl = arr
 	return nil
 }
 

--- a/gabikeys/sysparams.go
+++ b/gabikeys/sysparams.go
@@ -24,8 +24,8 @@ type (
 		Lstatzk uint
 	}
 
-	// DerivedParameters holds system parameters that can be drived from base
-	// systemparameters (BaseParameters)
+	// DerivedParameters holds system parameters that can be derived from base
+	// system parameters (BaseParameters)
 	DerivedParameters struct {
 		Le            uint
 		LeCommit      uint
@@ -39,7 +39,7 @@ type (
 	}
 )
 
-// defaultBaseParameters holds per keylength the base parameters.
+// defaultBaseParameters holds per key length the base parameters.
 var (
 	defaultBaseParameters = map[int]BaseParameters{
 		1024: {
@@ -65,7 +65,7 @@ var (
 		},
 	}
 
-	// DefaultSystemParameters holds per keylength the default parameters as are
+	// DefaultSystemParameters holds per key length the default parameters as are
 	// currently in use at the moment. This might (and probably will) change in the
 	// future.
 	DefaultSystemParameters = map[int]*SystemParameters{
@@ -74,7 +74,7 @@ var (
 		4096: {defaultBaseParameters[4096], MakeDerivedParameters(defaultBaseParameters[4096])},
 	}
 
-	// DefaultKeyLengths is a slice of integers holding the keylengths for which
+	// DefaultKeyLengths is a slice of integers holding the key lengths for which
 	// system parameters are available.
 	DefaultKeyLengths = getAvailableKeyLengths(DefaultSystemParameters)
 )

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,0 +1,8 @@
+package common
+
+import "io"
+
+// Close is a helper function for absorbing errors in the `defer x.Close()` pattern
+func Close(o io.Closer) {
+	_ = o.Close()
+}

--- a/internal/common/fastrandom.go
+++ b/internal/common/fastrandom.go
@@ -13,8 +13,7 @@ import (
 
 var globalCprng *CPRNG
 
-// Simple threadsafe cryptographically secure pseudo-random number generator.
-//
+// CPRNG is a simple thread-safe cryptographically secure pseudo-random number generator.
 // Implemented with AES in counter mode with the seed as key and an
 // atomic uint64 as counter.
 type CPRNG struct {
@@ -23,12 +22,12 @@ type CPRNG struct {
 }
 
 func NewCPRNG(seed *[32]byte) (*CPRNG, error) {
-	cipher, err := aes.NewCipher(seed[:])
+	c, err := aes.NewCipher(seed[:])
 	if err != nil {
 		return nil, err
 	}
 	return &CPRNG{
-		block:   cipher,
+		block:   c,
 		counter: 0,
 	}, nil
 }
@@ -81,7 +80,7 @@ func (c *CPRNG) Read(buf []byte) (n int, err error) {
 	return
 }
 
-// Derives a random number uniformly chosen below the given limit
+// FastRandomBigInt derives a random number uniformly chosen below the given limit
 // from a random 256 bit seed generated when the application starts.
 func FastRandomBigInt(limit *big.Int) *big.Int {
 	res, err := big.RandInt(globalCprng, limit)

--- a/internal/common/hashtool.go
+++ b/internal/common/hashtool.go
@@ -9,7 +9,7 @@ import (
 	gobig "math/big"
 )
 
-// hashCommit computes the sha256 hash over the asn1 representation of a slice
+// HashCommit computes the sha256 hash over the asn1 representation of a slice
 // of big integers and returns a positive big integer that can be represented
 // with that hash.
 func HashCommit(values []*big.Int, issig bool) *big.Int {
@@ -37,7 +37,7 @@ func HashCommit(values []*big.Int, issig bool) *big.Int {
 	return new(big.Int).SetBytes(sha[:])
 }
 
-// GetHashNumber uses a hash to generate random numbers of a given bitlength in the fiat-shamir heuristic
+// GetHashNumber uses a hash to generate random numbers of a given bit-length in the fiat-shamir heuristic
 func GetHashNumber(a *big.Int, b *big.Int, index int, bitlen uint) *big.Int {
 	tmp := []*big.Int{}
 	if a != nil {
@@ -63,8 +63,8 @@ func GetHashNumber(a *big.Int, b *big.Int, index int, bitlen uint) *big.Int {
 	return res
 }
 
-// intHashSha256 is a utility function compute the sha256 hash over a byte array
-// and return this hash as a big.Int.
+// IntHashSha256 is a utility function which computes the sha256 hash over a byte array
+// and returns this hash as a big.Int.
 func IntHashSha256(input []byte) *big.Int {
 	h := sha256.New()
 	h.Write(input)

--- a/internal/common/mathutil.go
+++ b/internal/common/mathutil.go
@@ -27,7 +27,7 @@ var (
 	bigEIGHT = big.NewInt(8)
 )
 
-// modInverse returns ia, the inverse of a in the multiplicative group of prime
+// ModInverse returns ia, the inverse of a in the multiplicative group of prime
 // order n. It requires that a be a member of the group (i.e. less than n).
 // This function was taken from Go's RSA implementation
 func ModInverse(a, n *big.Int) (ia *big.Int, ok bool) {
@@ -96,7 +96,7 @@ func RandomBigInt(numBits uint) (*big.Int, error) {
 	return big.RandInt(rand.Reader, t)
 }
 
-// legendreSymbol calculates the Legendre symbol (a/p).
+// LegendreSymbol calculates the Legendre symbol (a/p).
 func LegendreSymbol(a, p *big.Int) int {
 	// Adapted from: https://programmingpraxis.com/2012/05/01/legendres-symbol/
 	j := 1
@@ -134,7 +134,7 @@ func LegendreSymbol(a, p *big.Int) int {
 	return 0
 }
 
-// Find a number x (mod pa*pb) such that x = a (mod pa) and x = b (mod pb)
+// Crt finds a number x (mod pa*pb) such that x = a (mod pa) and x = b (mod pb)
 func Crt(a *big.Int, pa *big.Int, b *big.Int, pb *big.Int) *big.Int {
 	s1 := new(big.Int)
 	s2 := new(big.Int)
@@ -151,7 +151,7 @@ func Crt(a *big.Int, pa *big.Int, b *big.Int, pb *big.Int) *big.Int {
 	return result
 }
 
-// Express a number as sum of four squares
+// SumFourSquares expresses a number as sum of four squares
 // algorithm from "Randomized algorithms in number theory" by M. Rabin and J. Shallit
 func SumFourSquares(n *big.Int) (*big.Int, *big.Int, *big.Int, *big.Int) {
 	if n.BitLen() == 0 {
@@ -293,7 +293,7 @@ func sumFourSquaresSpecial(n *big.Int) (*big.Int, *big.Int, *big.Int, *big.Int) 
 	}
 }
 
-// Calculate sqrt modulo a prime
+// PrimeSqrt calculates sqrt modulo a prime
 func PrimeSqrt(a *big.Int, pa *big.Int) (*big.Int, bool) {
 	// Handle the case a == 0
 	if a.Cmp(bigZERO) == 0 {
@@ -350,7 +350,7 @@ func PrimeSqrt(a *big.Int, pa *big.Int) (*big.Int, bool) {
 	return R, true
 }
 
-// Calculate Sqrt modulo a number with given prime factors. Also allows 4 as a factor
+// ModSqrt calculates Sqrt modulo a number with given prime factors. Also allows 4 as a factor
 // All factors should be relatively prime to each other!
 func ModSqrt(a *big.Int, factors []*big.Int) (*big.Int, bool) {
 	n := big.NewInt(1) // Should be new big int!

--- a/internal/common/randomprime.go
+++ b/internal/common/randomprime.go
@@ -12,7 +12,7 @@ import (
 	"github.com/privacybydesign/gabi/big"
 )
 
-// SmallPrimes is a list of small, prime numbers that allows us to rapidly
+// SmallPrimes is a list of small prime numbers that allows us to rapidly
 // exclude some fraction of composite candidates when searching for a random
 // prime. This list is truncated at the point where SmallPrimesProduct exceeds
 // a uint64. It does not include two because we ensure that the candidates are
@@ -23,7 +23,7 @@ var SmallPrimes = []uint8{
 
 // SmallPrimesProduct is the product of the values in SmallPrimes and allows us
 // to reduce a candidate prime by this number and then determine whether it's
-// coprime to all the elements of SmallPrimes without further big.Int
+// coprime with all the elements of SmallPrimes without further big.Int
 // operations.
 var SmallPrimesProduct = new(big.Int).SetUint64(16294579238595022365)
 
@@ -35,7 +35,7 @@ func RandomPrimeInRange(rand io.Reader, start, length uint) (p *big.Int, err err
 		return
 	}
 
-	b := uint(length % 8)
+	b := length % 8
 	if b == 0 {
 		b = 8
 	}

--- a/issuer.go
+++ b/issuer.go
@@ -92,13 +92,12 @@ func randomElementMultiplicativeGroup(modulus *big.Int) (*big.Int, error) {
 // proveSignature returns a proof of knowledge of $e^{-1}$ in the signature.
 func (i *Issuer) proveSignature(signature *CLSignature, nonce2 *big.Int) (*ProofS, error) {
 	Q := new(big.Int).Exp(signature.A, signature.E, i.Pk.N)
-	groupModulus := new(big.Int).Mul(i.Sk.PPrime, i.Sk.QPrime)
-	d := new(big.Int).ModInverse(signature.E, groupModulus)
+	d := new(big.Int).ModInverse(signature.E, i.Sk.Order)
 	if d == nil {
 		return nil, common.ErrNoModInverse
 	}
 
-	eCommit, err := randomElementMultiplicativeGroup(groupModulus)
+	eCommit, err := randomElementMultiplicativeGroup(i.Sk.Order)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,7 @@ func (i *Issuer) proveSignature(signature *CLSignature, nonce2 *big.Int) (*Proof
 
 	c := common.HashCommit([]*big.Int{i.Context, Q, signature.A, nonce2, ACommit}, false)
 	eResponse := new(big.Int).Mul(c, d)
-	eResponse.Sub(eCommit, eResponse).Mod(eResponse, groupModulus)
+	eResponse.Sub(eCommit, eResponse).Mod(eResponse, i.Sk.Order)
 
 	return &ProofS{c, eResponse}, nil
 }

--- a/issuer.go
+++ b/issuer.go
@@ -79,8 +79,6 @@ func randomElementMultiplicativeGroup(modulus *big.Int) (*big.Int, error) {
 	t := new(big.Int)
 	var err error
 	for r.Sign() <= 0 || t.GCD(nil, nil, r, modulus).Cmp(big.NewInt(1)) != 0 {
-		// TODO: for memory/cpu efficiency re-use r's memory. See Go's
-		// implementation for finding a random prime.
 		r, err = big.RandInt(rand.Reader, modulus)
 		if err != nil {
 			return nil, err

--- a/keyproof/additionproof.go
+++ b/keyproof/additionproof.go
@@ -40,12 +40,12 @@ func newAdditionProofStructure(a1, a2, mod, result string, l uint) additionProof
 		myname: strings.Join([]string{a1, a2, mod, result, "add"}, "_"),
 	}
 	structure.addRepresentation = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{result, big.NewInt(1)},
 			{a1, big.NewInt(-1)},
 			{a2, big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{mod, strings.Join([]string{structure.myname, "mod"}, "_"), 1},
 			{"h", strings.Join([]string{structure.myname, "hider"}, "_"), 1},
 		},

--- a/keyproof/doc.go
+++ b/keyproof/doc.go
@@ -1,4 +1,5 @@
 /*
+Package keyproof
 ------------
 INTRODUCTION
 ------------
@@ -19,13 +20,13 @@ The implementation of this library consists of two parts: The group
 representation based zero knowledge proofs described in Camenisch et. al., and
 the more ad-hoc zero knowledge proofs for quasi safe prime products given in
 Gennaro. These proofs share little common infrastructure, and can be understood
-seperately.
+separately.
 
-Allthough their structure internally is rather different, and the generation
+Although their structure internally is rather different, and the generation
 logic is not shared, there are structural commonalities between how these
 proofs are implemented, which we will describe here.
 
-All of the zero knowledge proofs contained in this package are essentially
+All the zero knowledge proofs contained in this package are essentially
 interactive zero knowledge proofs, which are turned non-interactive using the
 Fiat-Shamir heuristic. The process of proving consists of two stages: first
 a set of commitments is generated for the proof, which is used to calculate a
@@ -47,7 +48,7 @@ demonstrating membership of some language of natural numbers:
 - Disjointprimeproduct allows for proofs that a given number N, which has
    already been shown that it is the product of at most two distinct primes, is
    in fact the product of precisely two primes
-- Finaly, Almostsafeprimeproduct shows that a product N of exactly two distinct
+- Finally, Almostsafeprimeproduct shows that a product N of exactly two distinct
    primes is the product of two almost safe primes, e.g. that there exists
    primes p, q, and integers n, m such that N = (2*p^n+1)*(2*q^m+1)
 
@@ -72,7 +73,7 @@ functions:
     sound.
  - (*VerifyProof), which given a structurally sound proof, validates whether it
     holds cryptographically.
-Aditionaly, almostSafePrimeProduct has two extra functions:
+Additionally, almostSafePrimeProduct has two extra functions:
  - almostSafePrimeProductBuildCommitments, which generates commitments that are
     used together with N to build the challenge for these proofs
  - almostSafePrimeProductExtractCommitments, which reconstructs the commitments
@@ -97,7 +98,7 @@ in this code in secret structs, which provide the basic tooling to make proofs
 on them. These are then used in combination with various representation and
 range proofs to show the needed relations.
 
-Each camenisch' based proof provides a similar interface in terms of types and
+Each Camenisch-based proof provides a similar interface in terms of types and
 functions. Each proof provides up to three types:
  - A structure type, describing abstractly the structure of the proof that
     is going to be given, as well as providing storage for any parameters in
@@ -137,13 +138,13 @@ Finally, each proof has a number of utility functions:
 To make it possible to chain these proofs together, and to hand off needed
 values between complicated subproofs, this library contains structures to aid
 in lookup of such values. These are BaseLookup, SecretLookup and ProofLookup.
-Any proof that needs to provides bases, secrets or proofdata to other
+Any proof that needs to provide bases, secrets or proofdata to other
 subproofs construct these. They provide lookup functions that can provide
 bases, secrets, hiders and proof results given the name of the relevant
-variable. This allows us to construct subproofs refering to variables by name
+variable. This allows us to construct subproofs referring to variables by name
 without having to know in the subproof what the exact name is any caller is
 going to use. This flexibility is needed because some subproofs are repeated
-many times in the overal proof that the key is properly generated.
+many times in the overall proof that the key is properly generated.
 
 Finally, pedersen contains the container for storing variables. It also exposes
 lookup interfaces for base, secret and proofdata related to its variable. It is
@@ -157,9 +158,9 @@ provided in this package. First, let us start with the basic building blocks
    where the bs are bases, v1 through vn are variables, and the ks and hs are
    numeric constants. These proofs rely on the proofdata of the variables to
    show validity, and thus only produce commitments
-- rangeproof provides proof of a representationproof statement, but additionaly
-   aranges for its own proof data such that it can show for a single variable
-   v occuring in the representationproof expression that it's value is bounded.
+- rangeproof provides proof of a representationproof statement, but additionally
+   arranges for its own proof data such that it can show for a single variable
+   v occurring in the representationproof expression that it's value is bounded.
 From these basic building blocks, the library then constructs proofs for basic
 operations:
 - pedersen provides a way to create a pedersen commitment on a value v, which
@@ -181,7 +182,7 @@ properly executed. In this:
 - expstepa proves that the current bit is 0 and that we have just forwarded the
    value
 - expstepb proves that the current bit is 1 and that we have properly done the
-   multiply with the correct 2-power of a.
+   multiplication with the correct 2-power of a.
 - exp contains one expstep for each bit, showing that all the steps are
    correctly done, and is also responsible for proving that all the
    intermediate values and fixed powers of a are in range and correctly
@@ -194,6 +195,6 @@ proofs:
 - issquareproof shows in zero knowledge that a known value a can be written
    as b*b (mod m), where b is not revealed.
 - validkeyproof shows, using primeproof, issquareproof and
-   quasisafeprimeproof that an idemix public key was properly generated.
+   quasisafeprimeproof that an Idemix public key was properly generated.
 */
 package keyproof

--- a/keyproof/exp.go
+++ b/keyproof/exp.go
@@ -88,19 +88,19 @@ func newExpProofStructure(base, exponent, mod, result string, bitlen uint) expPr
 
 	// Bit equality proof
 	structure.expBitEq = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
-			zkproof.LhsContribution{exponent, big.NewInt(-1)},
+		Lhs: []zkproof.LhsContribution{
+			{Base: exponent, Power: big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
-			zkproof.RhsContribution{"h", strings.Join([]string{structure.myname, "biteqhider"}, "_"), 1},
+		Rhs: []zkproof.RhsContribution{
+			{Base: "h", Secret: strings.Join([]string{structure.myname, "biteqhider"}, "_"), Power: 1},
 		},
 	}
 	for i := uint(0); i < bitlen; i++ {
 		structure.expBitEq.Lhs = append(
 			structure.expBitEq.Lhs,
 			zkproof.LhsContribution{
-				strings.Join([]string{structure.myname, "bit", fmt.Sprintf("%v", i)}, "_"),
-				new(big.Int).Lsh(big.NewInt(1), i),
+				Base:  strings.Join([]string{structure.myname, "bit", fmt.Sprintf("%v", i)}, "_"),
+				Power: new(big.Int).Lsh(big.NewInt(1), i),
 			})
 	}
 
@@ -147,12 +147,12 @@ func newExpProofStructure(base, exponent, mod, result string, bitlen uint) expPr
 	// start representation proof
 	structure.start = newPedersenStructure(strings.Join([]string{structure.myname, "start"}, "_"))
 	structure.startRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
-			zkproof.LhsContribution{strings.Join([]string{structure.myname, "start"}, "_"), big.NewInt(1)},
-			zkproof.LhsContribution{"g", big.NewInt(-1)},
+		Lhs: []zkproof.LhsContribution{
+			{strings.Join([]string{structure.myname, "start"}, "_"), big.NewInt(1)},
+			{"g", big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
-			zkproof.RhsContribution{"h", strings.Join([]string{structure.myname, "start", "hider"}, "_"), 1},
+		Rhs: []zkproof.RhsContribution{
+			{"h", strings.Join([]string{structure.myname, "start", "hider"}, "_"), 1},
 		},
 	}
 
@@ -263,8 +263,8 @@ func (s *expProofStructure) commitmentsFromSecrets(g zkproof.Group, list []*big.
 	}
 
 	// inner bases and secrets (this is ugly code, hopefully go2 will make this better someday)
-	baseList := []zkproof.BaseLookup{}
-	secretList := []zkproof.SecretLookup{}
+	var baseList []zkproof.BaseLookup
+	var secretList []zkproof.SecretLookup
 	for i := range commit.expBits {
 		baseList = append(baseList, &commit.expBits[i])
 		secretList = append(secretList, &commit.expBits[i])
@@ -541,8 +541,8 @@ func (s *expProofStructure) verifyProofStructure(challenge *big.Int, proof ExpPr
 
 func (s *expProofStructure) commitmentsFromProof(g zkproof.Group, list []*big.Int, challenge *big.Int, bases zkproof.BaseLookup, proofdata zkproof.ProofLookup, proof ExpProof) []*big.Int {
 	// inner bases and proofs (again hopefully go2 will make this better)
-	baseList := []zkproof.BaseLookup{}
-	proofList := []zkproof.ProofLookup{}
+	var baseList []zkproof.BaseLookup
+	var proofList []zkproof.ProofLookup
 	for i := range proof.ExpBitProofs {
 		proof.ExpBitProofs[i].setName(strings.Join([]string{s.myname, "bit", fmt.Sprintf("%v", i)}, "_"))
 		baseList = append(baseList, &proof.ExpBitProofs[i])

--- a/keyproof/expstep.go
+++ b/keyproof/expstep.go
@@ -117,7 +117,7 @@ func (s *expStepStructure) verifyProofStructure(challenge *big.Int, proof ExpSte
 	return s.stepa.verifyProofStructure(proof.Aproof) && s.stepb.verifyProofStructure(proof.Bproof)
 }
 
-func (s *expStepStructure) commitmentsFromProof(g zkproof.Group, list []*big.Int, challenge *big.Int, bases zkproof.BaseLookup, proof ExpStepProof) []*big.Int {
+func (s *expStepStructure) commitmentsFromProof(g zkproof.Group, list []*big.Int, _ *big.Int, bases zkproof.BaseLookup, proof ExpStepProof) []*big.Int {
 	list = s.stepa.commitmentsFromProof(g, list, proof.Achallenge, bases, proof.Aproof)
 	list = s.stepb.commitmentsFromProof(g, list, proof.Bchallenge, bases, proof.Bproof)
 	return list

--- a/keyproof/expstepa.go
+++ b/keyproof/expstepa.go
@@ -76,7 +76,7 @@ func (s *expStepAStructure) commitmentsFromSecrets(g zkproof.Group, list []*big.
 	return list, commit
 }
 
-func (s *expStepAStructure) buildProof(g zkproof.Group, challenge *big.Int, commit expStepACommit, secretdata zkproof.SecretLookup) ExpStepAProof {
+func (s *expStepAStructure) buildProof(g zkproof.Group, challenge *big.Int, commit expStepACommit, _ zkproof.SecretLookup) ExpStepAProof {
 	return ExpStepAProof{
 		Bit:           commit.bit.buildProof(g, challenge),
 		EqualityHider: commit.equalityHider.buildProof(g, challenge),

--- a/keyproof/expstepa.go
+++ b/keyproof/expstepa.go
@@ -36,20 +36,20 @@ func newExpStepAStructure(bitname, prename, postname string) expStepAStructure {
 		myname:   strings.Join([]string{bitname, prename, postname, "expa"}, "_"),
 	}
 	structure.bitRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
-			zkproof.LhsContribution{bitname, big.NewInt(1)},
+		Lhs: []zkproof.LhsContribution{
+			{bitname, big.NewInt(1)},
 		},
-		[]zkproof.RhsContribution{
-			zkproof.RhsContribution{"h", strings.Join([]string{bitname, "hider"}, "_"), 1},
+		Rhs: []zkproof.RhsContribution{
+			{"h", strings.Join([]string{bitname, "hider"}, "_"), 1},
 		},
 	}
 	structure.equalityRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
-			zkproof.LhsContribution{prename, big.NewInt(1)},
-			zkproof.LhsContribution{postname, big.NewInt(-1)},
+		Lhs: []zkproof.LhsContribution{
+			{prename, big.NewInt(1)},
+			{postname, big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
-			zkproof.RhsContribution{"h", strings.Join([]string{structure.myname, "eqhider"}, "_"), 1},
+		Rhs: []zkproof.RhsContribution{
+			{"h", strings.Join([]string{structure.myname, "eqhider"}, "_"), 1},
 		},
 	}
 	return structure

--- a/keyproof/expstepb.go
+++ b/keyproof/expstepb.go
@@ -39,11 +39,11 @@ func newExpStepBStructure(bitname, prename, postname, mulname, modname string, b
 		prePostMul: newMultiplicationProofStructure(mulname, prename, modname, postname, bitlen),
 	}
 	structure.bitRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{bitname, big.NewInt(1)},
 			{"g", big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", strings.Join([]string{bitname, "hider"}, "_"), 1},
 		},
 	}

--- a/keyproof/issquareproof.go
+++ b/keyproof/issquareproof.go
@@ -50,11 +50,11 @@ func newIsSquareProofStructure(N *big.Int, Squares []*big.Int) isSquareProofStru
 		squares:         make([]*big.Int, len(Squares)),
 		squaresPedersen: make([]pedersenStructure, len(Squares)),
 		nRep: zkproof.RepresentationProofStructure{
-			[]zkproof.LhsContribution{
+			Lhs: []zkproof.LhsContribution{
 				{"N", big.NewInt(-1)},
 				{"g", new(big.Int).Set(N)},
 			},
-			[]zkproof.RhsContribution{
+			Rhs: []zkproof.RhsContribution{
 				{"h", "N_hider", -1},
 			},
 		},
@@ -73,11 +73,11 @@ func newIsSquareProofStructure(N *big.Int, Squares []*big.Int) isSquareProofStru
 	// Setup representation proofs of square
 	for i, val := range result.squares {
 		result.squaresRep[i] = zkproof.RepresentationProofStructure{
-			[]zkproof.LhsContribution{
+			Lhs: []zkproof.LhsContribution{
 				{strings.Join([]string{"s", fmt.Sprintf("%v", i)}, "_"), big.NewInt(-1)},
 				{"g", new(big.Int).Set(val)},
 			},
-			[]zkproof.RhsContribution{
+			Rhs: []zkproof.RhsContribution{
 				{"h", strings.Join([]string{"s", fmt.Sprintf("%v", i), "hider"}, "_"), -1},
 			},
 		}

--- a/keyproof/multiplicationproof.go
+++ b/keyproof/multiplicationproof.go
@@ -42,10 +42,10 @@ func newMultiplicationProofStructure(m1, m2, mod, result string, l uint) multipl
 		myname: strings.Join([]string{m1, m2, mod, result, "mul"}, "_"),
 	}
 	structure.multRepresentation = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{result, big.NewInt(1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{m2, m1, 1},
 			{mod, strings.Join([]string{structure.myname, "mod"}, "_"), -1},
 			{"h", strings.Join([]string{structure.myname, "hider"}, "_"), 1},
@@ -59,7 +59,7 @@ func newMultiplicationProofStructure(m1, m2, mod, result string, l uint) multipl
 func (s *multiplicationProofStructure) commitmentsFromSecrets(g zkproof.Group, list []*big.Int, bases zkproof.BaseLookup, secretdata zkproof.SecretLookup) ([]*big.Int, multiplicationProofCommit) {
 	var commit multiplicationProofCommit
 
-	// Generate the neccesary commit data for our parts of the proof
+	// Generate the necessary commit data for our parts of the proof
 	list, commit.modMultPedersen = s.modMultPedersen.commitmentsFromSecrets(g, list, new(big.Int).Div(
 		new(big.Int).Sub(
 			new(big.Int).Mul(

--- a/keyproof/pedersen.go
+++ b/keyproof/pedersen.go
@@ -143,7 +143,7 @@ func (c *pedersenCommit) Base(name string) *big.Int {
 	}
 }
 
-func (c *pedersenCommit) Exp(ret *big.Int, name string, exp, P *big.Int) bool {
+func (c *pedersenCommit) Exp(ret *big.Int, name string, exp, _ *big.Int) bool {
 	if name != c.name {
 		return false
 	}

--- a/keyproof/pedersen.go
+++ b/keyproof/pedersen.go
@@ -35,10 +35,10 @@ func newPedersenStructure(name string) pedersenStructure {
 	return pedersenStructure{
 		name,
 		zkproof.RepresentationProofStructure{
-			[]zkproof.LhsContribution{
+			Lhs: []zkproof.LhsContribution{
 				{name, big.NewInt(1)},
 			},
-			[]zkproof.RhsContribution{
+			Rhs: []zkproof.RhsContribution{
 				{"g", name, 1},
 				{"h", strings.Join([]string{name, "hider"}, "_"), 1},
 			},

--- a/keyproof/primeproof.go
+++ b/keyproof/primeproof.go
@@ -96,12 +96,12 @@ func newPrimeProofStructure(name string, bitlen uint) primeProofStructure {
 
 	structure.halfP = newPedersenStructure(strings.Join([]string{structure.myname, "halfp"}, "_"))
 	structure.halfPRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{name, big.NewInt(1)},
 			{strings.Join([]string{structure.myname, "halfp"}, "_"), big.NewInt(-2)},
 			{"g", big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", strings.Join([]string{name, "hider"}, "_"), 1},
 			{"h", strings.Join([]string{structure.myname, "halfp", "hider"}, "_"), -2},
 		},
@@ -119,30 +119,30 @@ func newPrimeProofStructure(name string, bitlen uint) primeProofStructure {
 	structure.aRes = newPedersenStructure(strings.Join([]string{structure.myname, "ares"}, "_"))
 	structure.anegRes = newPedersenStructure(strings.Join([]string{structure.myname, "anegres"}, "_"))
 	structure.aPlus1ResRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{strings.Join([]string{structure.myname, "ares"}, "_"), big.NewInt(1)},
 			{"g", big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", strings.Join([]string{structure.myname, "aresplus1hider"}, "_"), 1},
 		},
 	}
 	structure.aMin1ResRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{strings.Join([]string{structure.myname, "ares"}, "_"), big.NewInt(1)},
 			{"g", big.NewInt(1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", strings.Join([]string{structure.myname, "aresmin1hider"}, "_"), 1},
 		},
 	}
 
 	structure.anegResRep = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{strings.Join([]string{structure.myname, "anegres"}, "_"), big.NewInt(1)},
 			{"g", big.NewInt(1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", strings.Join([]string{structure.myname, "anegres", "hider"}, "_"), 1},
 		},
 	}
@@ -236,12 +236,12 @@ func (s *primeProofStructure) commitmentsFromSecrets(g zkproof.Group, list []*bi
 
 	// Build structure for the a generation proofs
 	agenproof := zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{commit.prea.name, big.NewInt(1)},
 			{"g", new(big.Int).Mod(aAdd, g.Order)},
 			{commit.a.name, big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{s.primeName, commit.preaMod.name, 1},
 			{"h", commit.preaHider.name, 1},
 		},
@@ -301,12 +301,12 @@ func (s *primeProofStructure) buildProof(g zkproof.Group, challenge *big.Int, co
 	// Rebuild structure for the a generation proofs
 	aAdd := common.GetHashNumber(commit.prea.commit, nil, 0, s.bitlen)
 	agenproof := zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{commit.prea.name, big.NewInt(1)},
 			{"g", new(big.Int).Mod(aAdd, g.Order)},
 			{commit.a.name, big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{s.primeName, commit.preaMod.name, 1},
 			{"h", commit.preaHider.name, 1},
 		},
@@ -377,12 +377,12 @@ func (s *primeProofStructure) fakeProof(g zkproof.Group, challenge *big.Int) Pri
 	// Build the fake proof structure for the preaMod rangeproof
 	aAdd := common.GetHashNumber(proof.PreaCommit.Commit, nil, 0, s.bitlen)
 	agenproof := zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{strings.Join([]string{s.myname, "prea"}, "_"), big.NewInt(1)},
 			{"g", new(big.Int).Mod(aAdd, g.Order)},
 			{strings.Join([]string{s.myname, "a"}, "_"), big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{s.primeName, strings.Join([]string{s.myname, "preamod"}, "_"), 1},
 			{"h", strings.Join([]string{s.myname, "preahider"}, "_"), 1},
 		},
@@ -428,13 +428,13 @@ func (s *primeProofStructure) verifyProofStructure(challenge *big.Int, proof Pri
 	// Build the proof structure for the preaMod rangeproof
 	aAdd := common.GetHashNumber(proof.PreaCommit.Commit, nil, 0, s.bitlen)
 	agenproof := zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{strings.Join([]string{s.myname, "prea"}, "_"), big.NewInt(1)},
 			// LhsContribution{"g", new(big.Int).Mod(aAdd, g.order)},
 			{"g", aAdd},
 			{strings.Join([]string{s.myname, "a"}, "_"), big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{s.primeName, strings.Join([]string{s.myname, "preamod"}, "_"), 1},
 			{"h", strings.Join([]string{s.myname, "preahider"}, "_"), 1},
 		},
@@ -492,12 +492,12 @@ func (s *primeProofStructure) commitmentsFromProof(g zkproof.Group, list []*big.
 	// Build the proof structure for the preamod proofs
 	aAdd := common.GetHashNumber(proof.PreaCommit.Commit, nil, 0, s.bitlen)
 	agenproof := zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{strings.Join([]string{s.myname, "prea"}, "_"), big.NewInt(1)},
 			{"g", new(big.Int).Mod(aAdd, g.Order)},
 			{strings.Join([]string{s.myname, "a"}, "_"), big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{s.primeName, strings.Join([]string{s.myname, "preamod"}, "_"), 1},
 			{"h", strings.Join([]string{s.myname, "preahider"}, "_"), 1},
 		},

--- a/keyproof/progresslog.go
+++ b/keyproof/progresslog.go
@@ -10,8 +10,8 @@ type (
 	EmptyFollower struct{}
 )
 
-func (_ *EmptyFollower) StepStart(desc string, intermediates int) {}
-func (_ *EmptyFollower) Tick()                                    {}
-func (_ *EmptyFollower) StepDone()                                {}
+func (_ *EmptyFollower) StepStart(_ string, _ int) {}
+func (_ *EmptyFollower) Tick()                     {}
+func (_ *EmptyFollower) StepDone()                 {}
 
 var Follower ProgressFollower = &EmptyFollower{}

--- a/keyproof/rangeproof.go
+++ b/keyproof/rangeproof.go
@@ -206,7 +206,7 @@ func (s *rangeProofStructure) commitmentsFromProof(g zkproof.Group, list []*big.
 	return list
 }
 
-func (r *rangeCommitSecretLookup) Secret(name string) *big.Int {
+func (r *rangeCommitSecretLookup) Secret(_ string) *big.Int {
 	return nil
 }
 

--- a/keyproof/rangeproof.go
+++ b/keyproof/rangeproof.go
@@ -31,7 +31,7 @@ type (
 func (s *rangeProofStructure) commitmentsFromSecrets(g zkproof.Group, list []*big.Int, bases zkproof.BaseLookup, secretdata zkproof.SecretLookup) ([]*big.Int, rangeCommit) {
 	var commit rangeCommitSecretLookup
 
-	// Build up commit datastructure
+	// Build up commit data structure
 	commit.commits = map[string][]*big.Int{}
 	for _, curRhs := range s.Rhs {
 		commit.commits[curRhs.Secret] = []*big.Int{}
@@ -70,11 +70,11 @@ func (s *rangeProofStructure) commitmentsFromSecrets(g zkproof.Group, list []*bi
 }
 
 func (s *rangeProofStructure) buildProof(g zkproof.Group, challenge *big.Int, commit rangeCommit, secretdata zkproof.SecretLookup) RangeProof {
-	// For every value, build up results, handling the secret data seperately
+	// For every value, build up results, handling the secret data separately
 	proof := RangeProof{map[string][]*big.Int{}}
 	for name, clist := range commit.commits {
 
-		rlist := []*big.Int{}
+		var rlist []*big.Int
 		if name == s.rangeSecret {
 			// special treatment for range secret
 			resultOffset := new(big.Int).Lsh(big.NewInt(1), s.l2+rangeProofEpsilon+1)
@@ -113,13 +113,13 @@ func (s *rangeProofStructure) fakeProof(g zkproof.Group) RangeProof {
 	proof := RangeProof{map[string][]*big.Int{}}
 	for _, curRhs := range s.Rhs {
 		if curRhs.Secret == s.rangeSecret {
-			rlist := []*big.Int{}
+			var rlist []*big.Int
 			for i := 0; i < rangeProofIters; i++ {
 				rlist = append(rlist, common.FastRandomBigInt(genLimit))
 			}
 			proof.Results[curRhs.Secret] = rlist
 		} else {
-			rlist := []*big.Int{}
+			var rlist []*big.Int
 			for i := 0; i < rangeProofIters; i++ {
 				rlist = append(rlist, common.FastRandomBigInt(g.Order))
 			}

--- a/keyproof/rangeproof_test.go
+++ b/keyproof/rangeproof_test.go
@@ -77,10 +77,10 @@ func TestRangeProofBasic(t *testing.T) {
 
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"x", big.NewInt(1)},
+		{"x", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
+		{"g", "x", 1},
 	}
 	s.rangeSecret = "x"
 	s.l1 = 3
@@ -90,7 +90,7 @@ func TestRangeProofBasic(t *testing.T) {
 	secret.secrets = map[string]*big.Int{
 		"x": big.NewInt(7),
 	}
-	secret.randomizers = map[string]*big.Int{} // These shouldn't be neccessary, so detect use with a panic
+	secret.randomizers = map[string]*big.Int{} // These shouldn't be necessary, so detect use with a panic
 
 	var commit RangeTestCommit
 	commit.commits = map[string]*big.Int{
@@ -125,11 +125,11 @@ func TestRangeProofComplex(t *testing.T) {
 
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2
@@ -139,7 +139,7 @@ func TestRangeProofComplex(t *testing.T) {
 		"x":  big.NewInt(7),
 		"xh": big.NewInt(21),
 	}
-	secret.randomizers = map[string]*big.Int{} // These shouldn't be neccessary, so detect use with a panic
+	secret.randomizers = map[string]*big.Int{} // These shouldn't be necessary, so detect use with a panic
 
 	var commit RangeTestCommit
 	commit.commits = map[string]*big.Int{
@@ -174,11 +174,11 @@ func TestRangeProofVerifyStructureEmpty(t *testing.T) {
 	var proof RangeProof
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2
@@ -190,16 +190,16 @@ func TestRangeProofVerifyStructureMissingVar(t *testing.T) {
 	var proof RangeProof
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2
 
-	tlist := []*big.Int{}
+	var tlist []*big.Int
 	for i := 0; i < rangeProofIters; i++ {
 		tlist = append(tlist, big.NewInt(1))
 	}
@@ -215,16 +215,16 @@ func TestRangeProofVerifyStructureTooShortVar(t *testing.T) {
 	var proof RangeProof
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2
 
-	tlist := []*big.Int{}
+	var tlist []*big.Int
 	for i := 0; i < rangeProofIters; i++ {
 		tlist = append(tlist, big.NewInt(1))
 	}
@@ -247,21 +247,21 @@ func TestRangeProofVerifyStructureMissingNo(t *testing.T) {
 	var proof RangeProof
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2
 
-	tlist := []*big.Int{}
+	var tlist []*big.Int
 	for i := 0; i < rangeProofIters; i++ {
 		tlist = append(tlist, big.NewInt(1))
 	}
 
-	hlist := []*big.Int{}
+	var hlist []*big.Int
 	for i := 0; i < rangeProofIters; i++ {
 		hlist = append(hlist, big.NewInt(2))
 	}
@@ -282,11 +282,11 @@ func TestRangeProofFake(t *testing.T) {
 
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2
@@ -301,11 +301,11 @@ func TestRangeProofJSON(t *testing.T) {
 
 	var s rangeProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(1)},
+		{"c", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
-		zkproof.RhsContribution{"h", "xh", 1},
+		{"g", "x", 1},
+		{"h", "xh", 1},
 	}
 	s.l1 = 3
 	s.l2 = 2

--- a/keyproof/rangeproof_test.go
+++ b/keyproof/rangeproof_test.go
@@ -54,21 +54,6 @@ func (rc *RangeTestCommit) Exp(ret *big.Int, name string, exp, P *big.Int) bool 
 	return true
 }
 
-func listCmp(a []*big.Int, b []*big.Int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, ai := range a {
-		if ai == nil || b[i] == nil {
-			return false
-		}
-		if ai.Cmp(b[i]) != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func TestRangeProofBasic(t *testing.T) {
 	g, gok := zkproof.BuildGroup(big.NewInt(47))
 	require.True(t, gok, "Failed to setup group for Range proof testing")

--- a/keyproof/safeprimegen.go
+++ b/keyproof/safeprimegen.go
@@ -5,7 +5,7 @@ import (
 	"github.com/privacybydesign/gabi/safeprime"
 )
 
-// Performance parameter, defines ammount of extra bits allowed when using a convenient safe prime
+// Performance parameter, defines amount of extra bits allowed when using a convenient safe prime
 const convenientRange = 100
 
 // A convenient safe prime is a safe prime of the form
@@ -39,7 +39,7 @@ var convenientSafePrimes = []convenientSafePrime{
 
 func findConvenientPrime(size int) *big.Int {
 	for _, cp := range convenientSafePrimes {
-		if int(cp.Exp) > size && int(cp.Exp)-size < convenientRange {
+		if cp.Exp > size && cp.Exp-size < convenientRange {
 			var ret, diff big.Int
 			diff.SetUint64(uint64(cp.Diff))
 			ret.SetUint64(1)

--- a/keyproof/squarefree_test.go
+++ b/keyproof/squarefree_test.go
@@ -53,7 +53,7 @@ func TestSquareFreeVerifyStructure(t *testing.T) {
 
 	valBackup := proof.Responses[2]
 	proof.Responses[2] = nil
-	assert.False(t, squareFreeVerifyStructure(proof), "Accepting missing respone")
+	assert.False(t, squareFreeVerifyStructure(proof), "Accepting missing response")
 	proof.Responses[2] = valBackup
 
 	assert.True(t, squareFreeVerifyStructure(proof), "testcase corrupted testdata")

--- a/keyproof/validkeyproof.go
+++ b/keyproof/validkeyproof.go
@@ -52,34 +52,34 @@ func NewValidKeyProofStructure(N *big.Int, Bases []*big.Int) ValidKeyProofStruct
 	structure.qprime = newPedersenStructure("qprime")
 
 	structure.pPprimeRel = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{"p", big.NewInt(1)},
 			{"pprime", big.NewInt(-2)},
 			{"g", big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", "p_hider", 1},
 			{"h", "pprime_hider", -2},
 		},
 	}
 
 	structure.qQprimeRel = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{"q", big.NewInt(1)},
 			{"qprime", big.NewInt(-2)},
 			{"g", big.NewInt(-1)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"h", "q_hider", 1},
 			{"h", "qprime_hider", -2},
 		},
 	}
 
 	structure.pQNRel = zkproof.RepresentationProofStructure{
-		[]zkproof.LhsContribution{
+		Lhs: []zkproof.LhsContribution{
 			{"g", new(big.Int).Set(N)},
 		},
-		[]zkproof.RhsContribution{
+		Rhs: []zkproof.RhsContribution{
 			{"p", "q", 1},
 			{"h", "pqnrel", -1},
 		},

--- a/keyshare.go
+++ b/keyshare.go
@@ -6,21 +6,21 @@ import (
 	"github.com/privacybydesign/gabi/internal/common"
 )
 
-// Generate keyshare secret
+// NewKeyshareSecret generates keyshare secret
 func NewKeyshareSecret() (*big.Int, error) {
 	// This value should be 1 bit less than indicated by Lm, as it is combined with an equal-length value
 	// from the client, resulting in a combined value that should fit in Lm bits.
 	return common.RandomBigInt(gabikeys.DefaultSystemParameters[1024].Lm - 1)
 }
 
-// Generate commitments for the keyshare server for given set of keys
+// NewKeyshareCommitments generates commitments for the keyshare server for given set of keys
 func NewKeyshareCommitments(secret *big.Int, keys []*gabikeys.PublicKey) (*big.Int, []*ProofPCommitment, error) {
 	// Generate randomizer value.
 	// Given that with this zero knowledge proof we are hiding a secret of length params[1024].Lm,
 	// normally we would use params[1024].LmCommit here. Generally LmCommit = Lm + Lh + Lstatzk,
 	// where Lstatzk is the level of security with which the proof hides the secret.
 	// However, params[1024].Lstatzk = 80 while everywhere else we use Lstatzk = 128.
-	// So instead of using params[1024].LmCommit we recompute it with the Lstatzk of keylength 2048.
+	// So instead of using params[1024].LmCommit we recompute it with the Lstatzk of key length 2048.
 	randLength := gabikeys.DefaultSystemParameters[1024].Lm +
 		gabikeys.DefaultSystemParameters[1024].Lh +
 		gabikeys.DefaultSystemParameters[2048].Lstatzk
@@ -43,7 +43,7 @@ func NewKeyshareCommitments(secret *big.Int, keys []*gabikeys.PublicKey) (*big.I
 	return randomizer, exponentiatedCommitments, nil
 }
 
-// Generate keyshare response for a given challenge and commit, given a secret
+// KeyshareResponse generates the keyshare response for a given challenge and commit, given a secret
 func KeyshareResponse(secret, commit, challenge *big.Int, key *gabikeys.PublicKey) *ProofP {
 	return &ProofP{
 		P:         new(big.Int).Exp(key.R[0], secret, key.N),

--- a/prooflist.go
+++ b/prooflist.go
@@ -54,7 +54,7 @@ func (pl ProofList) GetFirstProofU() (*ProofU, error) {
 
 // challengeContributions collects and returns all the challenge contributions
 // of the proofs contained in the proof list.
-func (pl ProofList) challengeContributions(publicKeys []*gabikeys.PublicKey, context, nonce *big.Int) ([]*big.Int, error) {
+func (pl ProofList) challengeContributions(publicKeys []*gabikeys.PublicKey, _, _ *big.Int) ([]*big.Int, error) {
 	contributions := make([]*big.Int, 0, len(pl)*2)
 	for i, proof := range pl {
 		contrib, err := proof.ChallengeContribution(publicKeys[i])

--- a/proofs.go
+++ b/proofs.go
@@ -132,7 +132,7 @@ type ProofS struct {
 	EResponse *big.Int `json:"e_response"`
 }
 
-// Verify verifies the proof agains the given public key, signature, context,
+// Verify verifies the proof against the given public key, signature, context,
 // and nonce.
 func (p *ProofS) Verify(pk *gabikeys.PublicKey, signature *CLSignature, context, nonce *big.Int) bool {
 	// Reconstruct A_commit
@@ -164,6 +164,8 @@ type ProofD struct {
 	cachedRangeStructures map[int][]*rangeproof.ProofStructure
 }
 
+// MergeProofP merges a ProofP into the ProofD. The public key is only passed for consistency with
+// ProofU's MergeProofP method.
 func (p *ProofD) MergeProofP(proofP *ProofP, pk *gabikeys.PublicKey) {
 	p.SecretKeyResponse().Add(p.SecretKeyResponse(), proofP.SResponse)
 }
@@ -262,8 +264,8 @@ func (p *ProofD) HasNonRevocationProof() bool {
 	return p.NonRevocationProof != nil
 }
 
-// Verify verifies the proof against the given public key and the provided
-// reconstruted challenge.
+// VerifyWithChallenge verifies the proof against the given public key and the provided
+// reconstructed challenge.
 func (p *ProofD) VerifyWithChallenge(pk *gabikeys.PublicKey, reconstructedChallenge *big.Int) bool {
 	var notrevoked bool
 	// Validate non-revocation
@@ -371,7 +373,7 @@ type ProofPCommitment struct {
 	Pcommit *big.Int
 }
 
-// Generate nonce for use in proofs
+// GenerateNonce generates a nonce for use in proofs
 func GenerateNonce() (*big.Int, error) {
 	return common.RandomBigInt(gabikeys.DefaultSystemParameters[2048].Lstatzk)
 }

--- a/proofs.go
+++ b/proofs.go
@@ -164,9 +164,8 @@ type ProofD struct {
 	cachedRangeStructures map[int][]*rangeproof.ProofStructure
 }
 
-// MergeProofP merges a ProofP into the ProofD. The public key is only passed for consistency with
-// ProofU's MergeProofP method.
-func (p *ProofD) MergeProofP(proofP *ProofP, pk *gabikeys.PublicKey) {
+// MergeProofP merges a ProofP into the ProofD.
+func (p *ProofD) MergeProofP(proofP *ProofP, _ *gabikeys.PublicKey) {
 	p.SecretKeyResponse().Add(p.SecretKeyResponse(), proofP.SResponse)
 }
 

--- a/rangeproof/proof.go
+++ b/rangeproof/proof.go
@@ -489,6 +489,7 @@ func (p *Proof) ExtractStructure(index int, g *gabikeys.PublicKey) (*ProofStruct
 // ---
 // Commit structure keyproof interfaces
 // ---
+
 func (c *proofCommit) Secret(name string) *big.Int {
 	if name == "m" {
 		return c.m
@@ -569,6 +570,7 @@ func (c *proofCommit) Names() []string {
 // ---
 // Proof structure keyproof interfaces
 // ---
+
 func (p *proof) ProofResult(name string) *big.Int {
 	if name == "m" {
 		return p.MResponse

--- a/rangeproof/proof.go
+++ b/rangeproof/proof.go
@@ -41,7 +41,7 @@ where
 - v_5 = \sum_i d_i * v_i.
 
 The proof of soundness for this protocol is relatively straightforward, but as we are not aware of
-its occurence in literature, we provide it here for completeness.
+its occurrence in literature, we provide it here for completeness.
 
 ---
 
@@ -99,7 +99,7 @@ This shows that the existence of algorithm G with non-neglible success probabili
 strong RSA, hence the existence of algorithm A contradicts the strong RSA assumption.
 
 Notes:
-- The techniques used to fake issuance can be generalized to multiple issuances using techiques
+- The techniques used to fake issuance can be generalized to multiple issuances using techniques
   similar to those used in CL03 for lemmas 3-5; the rest of the proof then needs e to be replaced
   with E, the product of all used e_i's.
 - This proof nowhere uses that the amount of squares we use is three; hence it also works when using
@@ -184,7 +184,7 @@ func NewStatement(typ StatementType, bound *big.Int) (*Statement, error) {
 	return &Statement{Sign: sign, Factor: 1, Bound: new(big.Int).Set(bound)}, nil
 }
 
-// Create a new proof structure for proving a statement of the form sign(factor*m - bound) >= 0.
+// NewProofStructure creates a new proof structure for proving a statement of the form sign(factor*m - bound) >= 0.
 //
 // index specifies the index of the attribute.
 // splitter describes the method used for splitting numbers into sum of squares.
@@ -470,7 +470,7 @@ func (p *Proof) ProvenStatement() (StatementType, uint, *big.Int) {
 	return typ, factor, bound
 }
 
-// Extract proof structure from proof
+// ExtractStructure extracts the proof structure from proof
 func (p *Proof) ExtractStructure(index int, g *gabikeys.PublicKey) (*ProofStructure, error) {
 	// Check that all values needed for the structure are present and reasonable
 	//

--- a/rangeproof/splitutils.go
+++ b/rangeproof/splitutils.go
@@ -10,11 +10,11 @@ import (
 type (
 	// SquareSplitter provides a combined interface for all facets describing a method for splitting positive numbers into a sum of squares.
 	SquareSplitter interface {
-		// Ld - Number of bits per square
+		// Ld returns the number of bits per square
 		Ld() uint
-		// SquareCount - Number of squares in result
+		// SquareCount return the number of squares in result
 		SquareCount() int
-		// Split - Actual splitting function, on input delta, should return array x such that sum_i x_i^2 = delta and len(x) = SquareCount()
+		// Split is the actual splitting function. On input delta, it should return array x such that sum_i x_i^2 = delta and len(x) = SquareCount()
 		Split(*big.Int) ([]*big.Int, error)
 	}
 

--- a/rangeproof/splitutils.go
+++ b/rangeproof/splitutils.go
@@ -8,13 +8,13 @@ import (
 )
 
 type (
-	// SquareSplitter provides a combined interface for all facets describing a method for spliting positive numbers into a sum of squares.
+	// SquareSplitter provides a combined interface for all facets describing a method for splitting positive numbers into a sum of squares.
 	SquareSplitter interface {
-		// Number of bits per square
+		// Ld - Number of bits per square
 		Ld() uint
-		// Number of squares in result
+		// SquareCount - Number of squares in result
 		SquareCount() int
-		// Actual splitting function, on input delta, should return array x such that sum_i x_i^2 = delta and len(x) = SquareCount()
+		// Split - Actual splitting function, on input delta, should return array x such that sum_i x_i^2 = delta and len(x) = SquareCount()
 		Split(*big.Int) ([]*big.Int, error)
 	}
 
@@ -23,7 +23,7 @@ type (
 	FourSquaresSplitter struct{}
 )
 
-// Generate lookup table for splitting numbers into 3 squares containing entries up-to and including limit
+// GenerateSquaresTable generates lookup table for splitting numbers into 3 squares containing entries up-to and including limit
 // takes O(n^3/2)
 func GenerateSquaresTable(limit int64) *SquaresTable {
 	result := make(SquaresTable, limit+1)
@@ -65,7 +65,7 @@ func (t *SquaresTable) SquareCount() int {
 func (t *SquaresTable) Ld() uint {
 	l := len(*t)
 	ld := uint(0)
-	// Ld is number of bits of root of maximum value this table support, which is
+	// Ld is number of bits of root of maximum value this table supports, which is
 	// Ceil(Log4(len(l)*4)). Below loop calculates this by simply dividing
 	// by 4 until l is 0, and counting number of times needed.
 	// then compensating for the extra factor 4.

--- a/revocation/api.go
+++ b/revocation/api.go
@@ -104,7 +104,7 @@ type (
 	Event struct {
 		Index      uint64   `json:"i" gorm:"primary_key;column:eventindex"`
 		E          *big.Int `json:"e"`
-		ParentHash Hash     `json"parenthash"`
+		ParentHash Hash     `json:"parenthash"`
 	}
 
 	EventList struct {
@@ -121,7 +121,7 @@ type (
 	// the accumulator itself and a set of revocation attributes.
 	// Its hash structure makes this message into a chain with the SignedAccumulator on top:
 	// The accumulator contains the hash of the first Event, and each Event has a hash of its parent.
-	// Thus the signature over the accumulator effectively signs the entire Update message,
+	// Thus, the signature over the accumulator effectively signs the entire Update message,
 	// and the partial tree specified by Events is verifiable regardless of its length.
 	Update struct {
 		SignedAccumulator *SignedAccumulator
@@ -141,7 +141,7 @@ type (
 		// Accumulator against which the witness verifies.
 		SignedAccumulator *SignedAccumulator `json:"sacc"`
 		// Update is set to now whenever the witness is updated, or when the RA indicates
-		// there are no new updates. Thus it specifies up to what time our nonrevocation
+		// there are no new updates. Thus, it specifies up to what time our nonrevocation
 		// guarantees lasts.
 		Updated time.Time
 
@@ -351,7 +351,7 @@ func (update *Update) Prepend(eventlist *EventList) error {
 		return err
 	}
 
-	// update our instance only after no error has occured
+	// update our instance only after no error has occurred
 	*update = *n
 	return nil
 }

--- a/revocation/proof.go
+++ b/revocation/proof.go
@@ -425,7 +425,7 @@ func (s *proofStructure) commitmentsFromSecrets(g *gabikeys.PublicKey, list []*b
 	return list, commit
 }
 
-func (s *proofStructure) commitmentsFromProof(g *gabikeys.PublicKey, list []*big.Int, challenge *big.Int, bases zkproof.BaseLookup, proofdata zkproof.ProofLookup, proof *proof) []*big.Int {
+func (s *proofStructure) commitmentsFromProof(g *gabikeys.PublicKey, list []*big.Int, challenge *big.Int, _ zkproof.BaseLookup, proofdata zkproof.ProofLookup, proof *proof) []*big.Int {
 	proofs := zkproof.NewProofMerge(proof, proofdata)
 
 	b := zkproof.NewBaseMerge(g, &proofCommit{cr: proof.Cr, cu: proof.Cu, nu: proof.Nu})

--- a/revocation/proof.go
+++ b/revocation/proof.go
@@ -21,7 +21,7 @@ when revoking and does not change when adding new revocation handles to the accu
 The user proves knowledge of two numbers u and e, called the witness, which are such that the relation
     u^e = 𝛎 mod n
 holds, where 𝛎 (greek letter "nu") is the accumulator (the issuer's current "non-revocation publickey").
-Both u and e are kept secret to the user. Elsewhere the number e is included as an attribute in an
+Both u and e are kept secret to the user. Elsewhere, the number e is included as an attribute in an
 IRMA credential, and this zero-knowledge proof convinces the verifier that the containing credential
 is not revoked.
 
@@ -36,7 +36,7 @@ with the following differences.
 3. The interval [A, B] from which the witness e is chosen does not satisfy the relation
    B*2^(k'+k''+1) < A^2 - 1, which is unnecessary: as long as A > 2, witnesses are unforgeable,
    by a simple extension of the unforgeability proof of Theorem 3. See below.
-In the following we follow the lead of the other zero knowledge proofs implemented elsehwere in gabi.
+In the following we follow the lead of the other zero knowledge proofs implemented elsewhere in gabi.
 4. Secrets and randomizers within the zero-knowledge proofs are taken positive, instead of from
    symmetric intervals [-A,A].
 5. We use addition in the zero-knowledge proof responses: response = randomizer + challenge*secret.
@@ -47,7 +47,7 @@ In the following we follow the lead of the other zero knowledge proofs implement
 We claim, prove, and implement the following:
 Let [A, B] be the interval from which the number e from the witness (u,e) is chosen, as in the paper.
 Then witnesses are unforgeable as in theorem 3, if A > 2 and B < 2^(l_n-1) where l_n
-is the bitsize of the modulus n. In particular, it is not necesary to require A^2 > B
+is the bit size of the modulus n. In particular, it is not necessary to require A^2 > B
 like theorem 3 does.
 
 Proof: let (u')^(x') = u^x where x = x_1*...*x_n, and set d = gcd(x, x'), as in the proof.
@@ -61,8 +61,8 @@ to phi(n), works as is.
 The claim "d = gcd(x,x') => (d = 1 or d = x_j)" in the middle of the proof, which requires
 A^2 > B for its proof, is thus not necessary to use in the proof of theorem 3.
 
-Thus for unforgeability the size of e is not relevant. However, e should be chosen from a set so large
-that it is overhelmingly unlikely that any one prime e is chosen twice. Combining the prime counting
+Thus, for unforgeability the size of e is not relevant. However, e should be chosen from a set so large
+that it is overwhelmingly unlikely that any prime e is chosen twice. Combining the prime counting
 function with the birthday paradox and simplifying, one finds the following: if N witnesses are chosen
 from the set of primes smaller than B, then the collision chance P approximately equals
    P = 1 - e^(-N^2 ln(B)/B).

--- a/safeprime/safeprime.go
+++ b/safeprime/safeprime.go
@@ -13,7 +13,7 @@ import (
 	"github.com/privacybydesign/gabi/internal/common"
 )
 
-// GenerateConcurrent concurrently and continuously generates safeprimes on all CPU cores,
+// GenerateConcurrent concurrently and continuously generates safe primes on all CPU cores,
 // until the stop channel receives a struct or is closed. If an error is encountered, generation is
 // stopped in all goroutines, and the error is sent on the second return parameter.
 func GenerateConcurrent(bitsize int, stop chan struct{}) (<-chan *big.Int, <-chan error) {
@@ -21,7 +21,7 @@ func GenerateConcurrent(bitsize int, stop chan struct{}) (<-chan *big.Int, <-cha
 	ints := make(chan *big.Int, count)
 	errs := make(chan error, count)
 
-	// In order to succesfully close all goroutines below when the caller wants them to, they require
+	// In order to successfully close all goroutines below when the caller wants them to, they require
 	// a channel that is close()d: just sending a struct{}{} would stop one but not all goroutines.
 	// Instead of requiring the caller to close() the stop chan parameter we use our own chan for
 	// this, so that we always stop all goroutines independent of whether the caller close()s stop
@@ -35,7 +35,7 @@ func GenerateConcurrent(bitsize int, stop chan struct{}) (<-chan *big.Int, <-cha
 		}
 	}()
 
-	// Start safeprime generation goroutines
+	// Start safe prime generation goroutines
 	for i := 0; i < count; i++ {
 		go func() {
 			for {
@@ -87,7 +87,7 @@ func Generate(bitsize int, stop chan struct{}) (*big.Int, error) {
 		i          int
 	)
 
-	// The algorithm generates a prime q and then returns 2q+1. The latter must have length bitsize,
+	// The algorithm generates a prime q and then returns 2q+1. The latter must have length bit size,
 	// so the former must be one bit shorter.
 	bitsize--
 

--- a/safeprime/safeprime_test.go
+++ b/safeprime/safeprime_test.go
@@ -31,7 +31,7 @@ func TestGenerateConcurrent(t *testing.T) {
 	// Start generating safe primes
 	ints, errs := GenerateConcurrent(64, stop)
 
-	// Receive incoming safeprimes, or an error, until we stop
+	// Receive incoming safe primes, or an error, until we stop
 	for !stopped {
 		select {
 		case x := <-ints:

--- a/safeprime/test.go
+++ b/safeprime/test.go
@@ -2,11 +2,11 @@ package safeprime
 
 import "github.com/privacybydesign/gabi/big"
 
-// ProbablySafePrime reports whether x is probably safe prime, by calling big.Int.ProbablyPrime(n)
+// ProbablySafePrime reports whether x is probably a safe prime, by calling big.Int.ProbablyPrime(n)
 // on x as well as on (x-1)/2.
 //
-// If x is safe prime, ProbablySafePrime returns true.
-// If x is chosen randomly and not safe prime, ProbablyPrime probably returns false.
+// If x is a safe prime, ProbablySafePrime returns true.
+// If x is chosen randomly and not a safe prime, ProbablyPrime probably returns false.
 func ProbablySafePrime(x *big.Int, n int) bool {
 	if x.Cmp(two) <= 0 {
 		return false

--- a/zkproof/group.go
+++ b/zkproof/group.go
@@ -47,7 +47,7 @@ func BuildGroup(prime *big.Int) (Group, bool) {
 	return result, true
 }
 
-func (g *Group) Exp(ret *big.Int, name string, exp, P *big.Int) bool {
+func (g *Group) Exp(ret *big.Int, name string, exp, _ *big.Int) bool {
 	var table *exptable.Table
 	if name == "g" {
 		table = &g.GTable

--- a/zkproof/representationproof_test.go
+++ b/zkproof/representationproof_test.go
@@ -396,7 +396,7 @@ type TestFollower struct {
 	count int64
 }
 
-func (_ *TestFollower) StepStart(desc string, intermediates int) {}
+func (_ *TestFollower) StepStart(_ string, _ int) {}
 
 func (t *TestFollower) Tick() {
 	atomic.AddInt64(&t.count, 1)

--- a/zkproof/representationproof_test.go
+++ b/zkproof/representationproof_test.go
@@ -306,10 +306,10 @@ func TestRepresentationProofBasics(t *testing.T) {
 
 	var s zkproof.RepresentationProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"x", big.NewInt(1)},
+		{"x", big.NewInt(1)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 1},
+		{"g", "x", 1},
 	}
 
 	var secret RepTestSecret
@@ -343,11 +343,11 @@ func TestRepresentationProofComplex(t *testing.T) {
 
 	var s zkproof.RepresentationProofStructure
 	s.Lhs = []zkproof.LhsContribution{
-		zkproof.LhsContribution{"c", big.NewInt(4)},
+		{"c", big.NewInt(4)},
 	}
 	s.Rhs = []zkproof.RhsContribution{
-		zkproof.RhsContribution{"g", "x", 2},
-		zkproof.RhsContribution{"h", "y", 1},
+		{"g", "x", 2},
+		{"h", "y", 1},
 	}
 
 	keyproof.Follower.(*TestFollower).count = 0


### PR DESCRIPTION
- fix typo's
- fix quite some IDE warnings
- minor refactoring


A couple of code changes are a matter of taste. I followed the default Goland IDE settings.

potentially controversial changes that deserve extra attention:
- removed groupModulus from issuer's `proveSignature` method
- introduced vars instead of x := []Bla{} pattern (because of IDE default)
- removed quite some conversions (i double checked if the removal was ok but please check again)
- added some explicit names when creating structs